### PR TITLE
Adding Fidenza Server support

### DIFF
--- a/Classes/RandomBot.js
+++ b/Classes/RandomBot.js
@@ -26,7 +26,7 @@ class RandomBot {
   async initialize() {
     const projectList = await getArtBlocksPlatform();
     projectCount = projectList[projectList.length - 1];
-    console.log('Loading project count: ${projectCount}');
+    console.log(`Loading project count: ${projectCount}`);
   }
 
   async handleRandomMessage(msg) {
@@ -44,7 +44,7 @@ class RandomBot {
     let attempts = 0;
     while (attempts < 10) {
       const projectNumber = parseInt(Math.random() * projectCount);
-      console.log('trying to look for project ${projectNumber}');
+      console.log(`trying to look for project ${projectNumber}`);
       const projectData = await getArtBlocksProject(projectNumber);
       if (projectData) {
         const pieceNumber = parseInt(Math.random() * projectData.invocations);

--- a/Utils/activityTriager.js
+++ b/Utils/activityTriager.js
@@ -9,6 +9,7 @@ const CHANNEL_SALES = process.env.CHANNEL_SALES;
 const CHANNEL_LISTINGS = process.env.CHANNEL_LISTINGS;
 const CHANNEL_SQUIGGLE_SALES = process.env.CHANNEL_SQUIGGLE_SALES;
 const CHANNEL_SQUIGGLE_LISTINGS = process.env.CHANNEL_SQUIGGLE_LISTINGS;
+const CHANNEL_FIDENZA_SALES = process.env.CHANNEL_FIDENZA_SALES;
 
 // Addresses which should be omitted entirely from event feeds.
 const BAN_ADDRESSES = new Set([
@@ -131,11 +132,17 @@ async function triageActivityMessage(msg, bot) {
       if (artBlocksData.collection_name.includes('Chromie Squiggle')) {
         bot.channels.cache.get(CHANNEL_SQUIGGLE_SALES).send(embed);
       }
+      if (artBlocksData.collection_name.includes('Fidenza')) {
+        bot.channels.cache.get(CHANNEL_FIDENZA_SALES).send(embed);
+      }
     } else if (eventName.includes('Created')) {
       bot.channels.cache.get(CHANNEL_LISTINGS).send(embed);
       // Forward all Chromie Squiggles listings on to the DAO.
       if (artBlocksData.collection_name.includes('Chromie Squiggle')) {
         bot.channels.cache.get(CHANNEL_SQUIGGLE_LISTINGS).send(embed);
+      }
+      if (artBlocksData.collection_name.includes('Fidenza')) {
+        bot.channels.cache.get(CHANNEL_FIDENZA_SALES).send(embed);
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ const PROD_CHANNEL_ACTIVITY_ALL = process.env.PROD_CHANNEL_ACTIVITY_ALL;
 // Special Squiggle DAO honorary channel ID.
 const CHANNEL_SQUIGGLE_DAO_SQUIGGLE_SQUARE = process.env.CHANNEL_SQUIGGLE_DAO_SQUIGGLE_SQUARE;
 
+// Tyler Hobbs fidenza channel ID
+const CHANNEL_FIDENZA_GENERAL = process.env.CHANNEL_FIDENZA_GENERAL;
+
 // Curated artist Discord channel IDs.
 const CHANNEL_AARON_PENNE = process.env.CHANNEL_AARON_PENNE;
 const CHANNEL_ALEXIS_ANDRE = process.env.CHANNEL_ALEXIS_ANDRE;
@@ -862,6 +865,9 @@ bot.on('message', (msg) => {
       case CHANNEL_TYLER_HOBBS:
         fidenzaBot.handleNumberMessage(msg);
         break;
+      case CHANNEL_FIDENZA_GENERAL:
+	fidenzaBot.handleNumberMessage(msg);
+	break;
       case CHANNEL_SHVEMBLDR:
         blocksOfArtBot.handleNumberMessage(msg);
         break;


### PR DESCRIPTION
This adds #n fidenza functionality to #general and listing feed functionality to #sales-chat for the tylerxhobbs discord.

Add the following lines to .env when deploying:

CHANNEL_FIDENZA_SALES=880937060075192320
CHANNEL_FIDENZA_GENERAL=879488624197001293