### PR TITLE
Fix activity triager bug with channel lookup. 

### DIFF
--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -149,15 +149,16 @@ class ProjectConfig {
   routeProjectNumberMsg(channelID, msg) {
     const channel = this.channels[channelID];
     if (!channel) {
-      // should never occur for anything we are being asked to route
+      // only occurs when # messages sent from channels not being observed
       console.error(`Unknown channel ID: ${channelID}`);
       return;
     }
     const botName =
       channel.botNameFromNumberMsgContent(msg.content.toLowerCase());
     if (botName === null) {
-      // should never occur for anything we are being asked to route
+      // only occurs when # messages are sent in observed channels without project bots
       console.error(`Channel ID: ${channelID} does not have a ProjectBot`);
+      return;
     }
     this.projectBots[botName].handleNumberMessage(msg);
   }

--- a/Utils/activityTriager.js
+++ b/Utils/activityTriager.js
@@ -6,17 +6,17 @@ const projectConfig = require('../ProjectConfig/projectConfig').projectConfig;
 
 // Trade activity Discord channel IDs.
 const CHANNEL_SALES_CHAT =
-  projectConfig.chIdByName['general']['block-talk'];
+  projectConfig.chIdByName['block-talk'];
 const CHANNEL_SALES =
-  projectConfig.chIdByName['general']['sales-feed'];
+  projectConfig.chIdByName['sales-feed'];
 const CHANNEL_LISTINGS =
-  projectConfig.chIdByName['general']['listing-feed'];
+  projectConfig.chIdByName['listing-feed'];
 const CHANNEL_SQUIGGLE_SALES =
-  projectConfig.chIdByName['general']['squiggle_square'];
+  projectConfig.chIdByName['squiggle_square'];
 const CHANNEL_SQUIGGLE_LISTINGS =
-  projectConfig.chIdByName['general']['squiggle-listings'];
+  projectConfig.chIdByName['squiggle-listings'];
 const CHANNEL_FIDENZA_SALES =
-  projectConfig.chIdByName['general']['fidenza-sales'];
+  projectConfig.chIdByName['fidenza-sales'];
 
 // Addresses which should be omitted entirely from event feeds.
 const BAN_ADDRESSES = new Set([


### PR DESCRIPTION
Fix bug in activityTriager having to do with channel lookups.

Also fix potential crash by adding a missing return statement in projectConfig.js.