### PR TITLE
Fix global replace to implement Owner/Winner -> Seller/Buyer

### DIFF
--- a/Utils/activityTriager.js
+++ b/Utils/activityTriager.js
@@ -126,10 +126,10 @@ async function triageActivityMessage(msg, bot) {
     description = description.replace(/\(ethereum\)/g, '');
 
     // Replace "Owner" with "Seller"
-    description = description.replace(/\(Owner\)/g, 'Seller');
+    description = description.replace(/Owner/, 'Seller');
     
     // Replace "Winner" with "Buyer"
-    description = description.replace(/\(Winner\)/g, 'Buyer');
+    description = description.replace(/Winner/g, 'Buyer');
     
     // Update description with parsed and modified string.
     embed.setDescription(description.trim());


### PR DESCRIPTION
Parenthesis in regex were causing artbot to not replace Owner and Winer with Seller and Buyer, respectively. Also, updated to only globally replace Winner since Owner will be at the start of description, and that is all that we want to replace.