### PR TITLE
editionSize instead of editionsize

### DIFF
--- a/ProjectConfig/projectBots.json
+++ b/ProjectConfig/projectBots.json
@@ -484,7 +484,7 @@
     "hashtractorsBot": {
         "projectNumber": 90,
         "coreContract": "V2",
-        "editionsize": 128,
-        "projectName":"Hashtractors"
+        "editionSize": 128,
+        "projectName": "Hashtractors"
     }
 }


### PR DESCRIPTION
key error was killing OpenSea token metadata lookup. Will add to (eventual) tests 😄 