### PR TITLE
fix bug where token ID Triggers were not being properly iterated

### DIFF
--- a/ProjectConfig/channels_dev.json
+++ b/ProjectConfig/channels_dev.json
@@ -14,7 +14,15 @@
                     "eternal",
                     "pump"
                 ]
-            }
+            },
+            "tokenIdTriggers": [
+                {
+                    "squiggleBot": [
+                        1000,
+                        null
+                    ]
+                }
+            ]
         }
     },
     "838422388478836786": {

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -21,7 +21,7 @@ Object.keys(PROJECT_BOTS).forEach((_bot) => {
 
 // utility class that routes number messages for each channel
 class Channel {
-  constructor({ name, projectBotHandlers }) {
+  constructor({ name, projectBotHandlers}) {
     this.name = name;
     this.hasProjectBotHandler = !!projectBotHandlers;
     if (projectBotHandlers) {
@@ -65,11 +65,14 @@ class Channel {
       if (tokenID) {
         tokenID = parseInt(tokenID[0]);
         tokenIdTriggerLoop:
-        for (const [botName, triggers] of Object.entries(this.tokenIdTriggers)) {
-          if (Channel._inRange(tokenID, ...triggers)) {
-            projectBotName = botName;
-            break tokenIdTriggerLoop;
-          };
+        for (let i = 0; i < this.tokenIdTriggers.length; i++) {
+          const _botTriggerRange = this.tokenIdTriggers[i];
+          for (const [botName, triggers] of Object.entries(_botTriggerRange)) {
+            if (Channel._inRange(tokenID, ...triggers)) {
+              projectBotName = botName;
+              break tokenIdTriggerLoop;
+            };
+          }
         };
       };
     };


### PR DESCRIPTION
This fixes a bug dealing with how token ID Triggers were being iterated. It was causing the bot to crash in stefan-contiero's channel. channels-dev.json adjusted to test out the exact situation causing the crash. verified to be working while testing with artbot-jr.