### PR TITLE
Add IC Support in Tyler Hobbs Server

### DIFF
--- a/ProjectConfig/channels.json
+++ b/ProjectConfig/channels.json
@@ -366,9 +366,16 @@
         }
     },
     "879488624197001293": {
-        "name": "Server: Tyler Hobbs (879488624197001287), CH: fidenza",
+        "name": "Server: Tyler Hobbs (879488624197001287), CH: the-place-to-be",
         "projectBotHandlers": {
-            "default": "fidenzaBot"
+            "default": "fidenzaBot",            
+            "stringTriggers": {
+                "icBot": [
+                    "ic",
+                    "incomplete",
+                    "control"
+                ]
+            }
         }
     },
     "846619538320785448": {


### PR DESCRIPTION
Adds the icBot to the Tyler Hobbs server. Also updates the channel name from "fidenza" to "the-place-to-be", which is the new name of the main channel.

Please let me know if anything looks incorrect here! Thanks for your work :)