### PR TITLE
Add additional channels for "Tyler Hobbs" server

### DIFF
--- a/ProjectConfig/channels.json
+++ b/ProjectConfig/channels.json
@@ -394,12 +394,10 @@
     "929413828968611880": {
         "name": "Server: Tyler Hobbs (879488624197001287), CH: incomplete-control",
         "projectBotHandlers": {
-            "default": "fidenzaBot",
+            "default": "icBot",
             "stringTriggers": {
-                "icBot": [
-                    "ic",
-                    "incomplete",
-                    "control"
+                "fidenzaBot": [
+                    "fidenza"
                 ]
             }
         }

--- a/ProjectConfig/channels.json
+++ b/ProjectConfig/channels.json
@@ -378,6 +378,32 @@
             }
         }
     },
+    "898335291008487464": {
+        "name": "Server: Tyler Hobbs (879488624197001287), CH: fidenza-owners",
+        "projectBotHandlers": {
+            "default": "fidenzaBot",
+            "stringTriggers": {
+                "icBot": [
+                    "ic",
+                    "incomplete",
+                    "control"
+                ]
+            }
+        }
+    },
+    "929413828968611880": {
+        "name": "Server: Tyler Hobbs (879488624197001287), CH: incomplete-control",
+        "projectBotHandlers": {
+            "default": "fidenzaBot",
+            "stringTriggers": {
+                "icBot": [
+                    "ic",
+                    "incomplete",
+                    "control"
+                ]
+            }
+        }
+    },
     "846619538320785448": {
         "name": "shvembldr",
         "projectBotHandlers": {
@@ -547,6 +573,16 @@
         "name": "squiggle-listings"
     },
     "880937060075192320": {
-        "name": "fidenza-and-ic-sales"
+        "name": "fidenza-and-ic-sales",
+        "projectBotHandlers": {
+            "default": "fidenzaBot",
+            "stringTriggers": {
+                "icBot": [
+                    "ic",
+                    "incomplete",
+                    "control"
+                ]
+            }
+        }
     }
 }


### PR DESCRIPTION
@thobbs requested that arbot monitor some additional channels on his "Tyler Hobbs" server. This PR attempts to accomplish this by registering `fidenzaBot` and `icBot` as handlers for each of these channels within `ProjectConfig/channels.json`.

Thank you all for your feedback and consideration. Please feel free to make edits as you see fit.

Notes:
- The `"name"` fields for the two new channels were chosen in order to conform to the `"name"` of the existing "the-place-to-be" channel for the "Tyler Hobbs" server.
- After making my edits, I checked for conflicting channel IDs by running
    ```bash
    grep -E "898335291008487464|929413828968611880|880937060075192320" ProjectConfig/channels.json
    ```
    and this did not show any conflicting channel IDs.
- The two added channels, `fidenza-owners` and `incomplete-control`, are private channels, but arbot has been given member access.