### PR TITLE
Have bot request basic information from subgraph vs. pull from config

### DIFF
--- a/ProjectConfig/projectBots.json
+++ b/ProjectConfig/projectBots.json
@@ -215,7 +215,7 @@
     },
     "returnBot": {
         "projectNumber": 77
-    }
+    },
     "ritualBot": {
         "projectNumber": 172
     },

--- a/ProjectConfig/projectBots.json
+++ b/ProjectConfig/projectBots.json
@@ -1,149 +1,83 @@
 {
     "singularityBot": {
-        "projectNumber": 8,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Singularity"
+        "projectNumber": 8
     },
     "ignitionBot": {
-        "projectNumber": 9,
-        "coreContract": "V2",
-        "editionSize": 512,
-        "projectName": "Ignition"
+        "projectNumber": 9
     },
     "squiggleBot": {
         "projectNumber": 0,
-        "coreContract": "OG",
-        "editionSize": 10000,
-        "projectName": "Chromie Squiggle",
         "namedMappings": {
             "sets": "squiggleSets.json"
         }
     },
     "ringersBot": {
         "projectNumber": 13,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Ringers",
         "namedMappings": {
             "sets": "ringerSets.json",
             "singles": "ringerSingles.json"
         }
     },
     "genesisBot": {
-        "projectNumber": 1,
-        "coreContract": "OG",
-        "editionSize": 512,
-        "projectName": "Genesis"
+        "projectNumber": 1
     },
     "constructionBot": {
-        "projectNumber": 2,
-        "coreContract": "OG",
-        "editionSize": 500,
-        "projectName": "Construction Token"
+        "projectNumber": 2
     },
     "dynamicSlicesBot": {
-        "projectNumber": 4,
-        "coreContract": "V2",
-        "editionSize": 512,
-        "projectName": "Dynamic Slices"
+        "projectNumber": 4
     },
     "deconstructionsBot": {
-        "projectNumber": 7,
-        "coreContract": "V2",
-        "editionSize": 200,
-        "projectName": "Elevated Deconstructions"
+        "projectNumber": 7
     },
     "nimbudsBot": {
-        "projectNumber": 10,
-        "coreContract": "V2",
-        "editionSize": 400,
-        "projectName": "Nimbuds"
+        "projectNumber": 10
     },
     "hyperhashBot": {
-        "projectNumber": 11,
-        "coreContract": "V2",
-        "editionSize": 369,
-        "projectName": "HyperHash"
+        "projectNumber": 11
     },
     "unigridsBot": {
-        "projectNumber": 12,
-        "coreContract": "V2",
-        "editionSize": 421,
-        "projectName": "Unigrids"
+        "projectNumber": 12
     },
     "27bitBot": {
-        "projectNumber": 21,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "27-Bit Digital"
+        "projectNumber": 21
     },
     "spectronBot": {
-        "projectNumber": 17,
-        "coreContract": "V2",
-        "editionSize": 400,
-        "projectName": "Spectron"
+        "projectNumber": 17
     },
     "cryptoblotBot": {
-        "projectNumber": 3,
-        "coreContract": "V2",
-        "editionSize": 1921,
-        "projectName": "Cryptoblots"
+        "projectNumber": 3
     },
     "archetypeBot": {
         "projectNumber": 23,
-        "coreContract": "V2",
-        "editionSize": 600,
-        "projectName": "Archetype",
         "namedMappings": {
             "sets": "archetypeSets.json"
         }
     },
     "minutesBot": {
-        "projectNumber": 27,
-        "coreContract": "V2",
-        "editionSize": 720,
-        "projectName": "720 Minutes"
+        "projectNumber": 27
     },
     "apparitionsBot": {
         "projectNumber": 28,
-        "coreContract": "V2",
-        "editionSize": 1500,
-        "projectName": "Apparitions",
         "namedMappings": {
             "sets": "apparitionSets.json",
             "singles": "apparitionSingles.json"
         }
     },
     "inspiralsBot": {
-        "projectNumber": 29,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Inspirals"
+        "projectNumber": 29
     },
     "aerialViewBot": {
-        "projectNumber": 35,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Aerial View"
+        "projectNumber": 35
     },
     "synapsesBot": {
-        "projectNumber": 39,
-        "coreContract": "V2",
-        "editionSize": 700,
-        "projectName": "Synapses"
+        "projectNumber": 39
     },
     "algobotsBot": {
-        "projectNumber": 40,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "Algobots"
+        "projectNumber": 40
     },
     "elementalsBot": {
         "projectNumber": 41,
-        "coreContract": "V2",
-        "editionSize": 600,
-        "projectName": "Elementals",
         "namedMappings": {
             "sets": "elementalsSets.json",
             "singles": "elementalsSingles.json"
@@ -151,9 +85,6 @@
     },
     "subscapesBot": {
         "projectNumber": 53,
-        "coreContract": "V2",
-        "editionSize": 650,
-        "projectName": "Subscapes",
         "namedMappings": {
             "sets": "subscapeSets.json",
             "singles": "subscapeSingles.json"
@@ -161,404 +92,218 @@
     },
     "watercolorDreamsBot": {
         "projectNumber": 59,
-        "coreContract": "V2",
-        "editionSize": 600,
-        "projectName": "Watercolor Dreams",
         "namedMappings": {
             "sets": "watercolorDreamSets.json",
             "singles": "watercolorDreamSingles.json"
         }
     },
     "bubbleBlobbyBot": {
-        "projectNumber": 62,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "Bubble Blobby"
+        "projectNumber": 62
     },
     "algoRhythmsBot": {
-        "projectNumber": 64,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "AlgoRhythms"
+        "projectNumber": 64
     },
     "frammentiBot": {
-        "projectNumber": 72,
-        "coreContract": "V2",
-        "editionSize": 555,
-        "projectName": "Frammenti"
+        "projectNumber": 72
     },
     "blocksOfArtBot": {
-        "projectNumber": 74,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "The Blocks of Art"
+        "projectNumber": 74
     },
     "fidenzaBot": {
         "projectNumber": 78,
-        "coreContract": "V2",
-        "editionSize": 999,
-        "projectName": "Fidenza",
         "namedMappings": {
             "sets": "fidenzaSets.json"
         }
     },
     "dreamsBot": {
         "projectNumber": 89,
-        "coreContract": "V2",
-        "editionSize": 700,
-        "projectName": "Dreams",
         "namedMappings": {
             "sets": "dreamSets.json",
             "singles": "dreamSingles.json"
         }
     },
     "centuryBot": {
-        "projectNumber": 100,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Century"
+        "projectNumber": 100
     },
     "glitchBot": {
-        "projectNumber": 114,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "glitch crystal monsters"
+        "projectNumber": 114
     },
     "endlessBot": {
-        "projectNumber": 120,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Endless Nameless"
+        "projectNumber": 120
     },
     "diveBot": {
-        "projectNumber": 212,
-        "coreContract": "V2",
-        "editionSize": 333,
-        "projectName": "Dive"
+        "projectNumber": 212
     },
     "pigmentsBot": {
         "projectNumber": 129,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Pigments",
         "namedMappings": {
             "sets": "pigmentsSets.json"
         }
     },
     "phasesBot": {
-        "projectNumber": 143,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Phase"
+        "projectNumber": 143
     },
     "paradeBot": {
-        "projectNumber": 197,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Parade"
+        "projectNumber": 197
     },
     "traversalsBot": {
-        "projectNumber": 65,
-        "coreContract": "V2",
-        "editionSize": 150,
-        "projectName": "Traversals"
+        "projectNumber": 65
     },
     "viewCardBot": {
-        "projectNumber": 6,
-        "coreContract": "V2",
-        "editionSize": 41,
-        "projectName": "View Card"
+        "projectNumber": 6
     },
     "colorStudyBot": {
-        "projectNumber": 16,
-        "coreContract": "V2",
-        "editionSize": 2000,
-        "projectName": "Color Study"
+        "projectNumber": 16
     },
     "rhythmBot": {
-        "projectNumber": 57,
-        "coreContract": "V2",
-        "editionSize": 400,
-        "projectName": "Rhythm"
+        "projectNumber": 57
     },
     "gen2Bot": {
-        "projectNumber": 18,
-        "coreContract": "V2",
-        "editionSize": 256,
-        "projectName": "Gen 2"
+        "projectNumber": 18
     },
     "gen3Bot": {
-        "projectNumber": 48,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Gen 3"
+        "projectNumber": 48
     },
     "sentienceBot": {
-        "projectNumber": 20,
-        "coreContract": "V2",
-        "editionSize": 144,
-        "projectName": "Sentience"
+        "projectNumber": 20
     },
     "cyberCitiesBot": {
-        "projectNumber": 14,
-        "coreContract": "V2",
-        "editionSize": 256,
-        "projectName": "Cyber Cities"
+        "projectNumber": 14
     },
     "hieroglyphsBot": {
-        "projectNumber": 30,
-        "coreContract": "V2",
-        "editionSize": 1250,
-        "projectName": "Hieroglyphs"
+        "projectNumber": 30
     },
     "eternalPumpBot": {
-        "projectNumber": 22,
-        "coreContract": "V2",
-        "editionSize": 50,
-        "projectName": "The Eternal Pump"
+        "projectNumber": 22
     },
     "utopiaBot": {
-        "projectNumber": 15,
-        "coreContract": "V2",
-        "editionSize": 256,
-        "projectName": "Utopia"
+        "projectNumber": 15
     },
     "r3sonanceBot": {
-        "projectNumber": 19,
-        "coreContract": "V2",
-        "editionSize": 512,
-        "projectName": "R3sonance"
+        "projectNumber": 19
     },
     "auroraIvBot": {
-        "projectNumber": 56,
-        "coreContract": "V2",
-        "editionSize": 128,
-        "projectName": "Aurora IV"
+        "projectNumber": 56
     },
     "pixelGlassBot": {
-        "projectNumber": 24,
-        "coreContract": "V2",
-        "editionSize": 256,
-        "projectName": "Pixel Glass"
+        "projectNumber": 24
     },
     "energySculptureBot": {
-        "projectNumber": 26,
-        "coreContract": "V2",
-        "editionSize": 369,
-        "projectName": "EnergySculpture"
+        "projectNumber": 26
     },
     "pathfindersBot": {
-        "projectNumber": 25,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Pathfinders"
+        "projectNumber": 25
     },
     "paperArmadaBot": {
         "projectNumber": 37,
-        "coreContract": "V2",
-        "editionSize": 3000,
-        "projectName": "Paper Armada",
         "namedMappings": {
             "sets": "paperArmadaSets.json",
             "singles": "paperArmadaSingles.json"
         }
     },
     "voidBot": {
-        "projectNumber": 42,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "Void"
+        "projectNumber": 42
     },
     "messengersBot": {
-        "projectNumber": 68,
-        "coreContract": "V2",
-        "editionSize": 350,
-        "projectName": "Messengers"
+        "projectNumber": 68
     },
     "obiceraBot": {
-        "projectNumber": 130,
-        "coreContract": "V2",
-        "editionSize": 529,
-        "projectName": "Obicera"
+        "projectNumber": 130
     },
     "heuresBot": {
-        "projectNumber": 201,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "24 Heures"
+        "projectNumber": 201
     },
     "returnBot": {
-        "projectNumber": 77,
-        "coreContract": "V2",
-        "editionSize": 300,
-        "projectName": "Return"
-    },
+        "projectNumber": 77
+    }
     "ritualBot": {
-        "projectNumber": 172,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Rituals"
+        "projectNumber": 172
     },
     "divisionsBot": {
-        "projectNumber": 108,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "Divisions"
+        "projectNumber": 108
     },
     "eccentricsBot": {
-        "projectNumber": 104,
-        "coreContract": "V2",
-        "editionSize": 400,
-        "projectName": "Eccentrics"
+        "projectNumber": 104
     },
     "eccentrics2Bot": {
-        "projectNumber": 139,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "Eccentrics 2: Orbits"
+        "projectNumber": 139
     },
     "ecumenopolisBot": {
-        "projectNumber": 119,
-        "coreContract": "V2",
-        "editionSize": 676,
-        "projectName": "Ecumenopolis"
+        "projectNumber": 119
     },
     "rinascitaBot": {
-        "projectNumber": 121,
-        "coreContract": "V2",
-        "editionSize": 1111,
-        "projectName": "Rinascita"
+        "projectNumber": 121
     },
     "scribbledBot": {
         "projectNumber": 131,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Scribbled Boundaries",
         "namedMappings": {
             "sets": "scribbledSets.json",
             "singles": "scribbledSingles.json"
         }
     },
     "saturazioneBot": {
-        "projectNumber": 200,
-        "coreContract": "V2",
-        "editionSize": 444,
-        "projectName": "Saturazione"
+        "projectNumber": 200
     },
     "octoGardenBot": {
-        "projectNumber": 103,
-        "coreContract": "V2",
-        "editionSize": 333,
-        "projectName": "Octo Garden"
+        "projectNumber": 103
     },
     "geometryRunnersBot": {
         "projectNumber": 138,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Geometry Runners",
         "namedMappings": {
             "sets": "geometryRunnersSets.json",
             "singles": "geometryRunnersSingles.json"
         }
     },
     "lightBeamsBot": {
-        "projectNumber": 32,
-        "coreContract": "V2",
-        "editionSize": 150,
-        "projectName": "Light Beams"
+        "projectNumber": 32
     },
     "transitionsBot": {
-        "projectNumber": 117,
-        "coreContract": "V2",
-        "editionSize": 4712,
-        "projectName": "Transitions"
+        "projectNumber": 117
     },
     "fragmentsBot": {
-        "projectNumber": 159,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Fragments"
+        "projectNumber": 159
     },
     "trossetsBot": {
-        "projectNumber": 147,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Trossets"
+        "projectNumber": 147
     },
     "skulptuurBot": {
-        "projectNumber": 173,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Skulptuur"
+        "projectNumber": 173
     },
     "phototaxisBot": {
-        "projectNumber": 164,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Phototaxis"
+        "projectNumber": 164
     },
     "meridianBot": {
-        "projectNumber": 163,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Meridian"
+        "projectNumber": 163
     },
     "portalBot": {
-        "projectNumber": 94,
-        "coreContract": "V2",
-        "editionSize": 10,
-        "projectName": "Portal"
+        "projectNumber": 94
     },
     "neighborhoodBot": {
-        "projectNumber": 146,
-        "coreContract": "V2",
-        "editionSize": 312,
-        "projectName": "Neighborhood"
+        "projectNumber": 146
     },
     "hashtractorsBot": {
-        "projectNumber": 90,
-        "coreContract": "V2",
-        "editionSize": 128,
-        "projectName": "Hashtractors"
+        "projectNumber": 90
     },
     "444(4)Bot": {
-        "projectNumber": 191,
-        "coreContract": "V2",
-        "editionSize": 444,
-        "projectName": "444(4)"
+        "projectNumber": 191
     },
     "alienInsectsBot": {
-        "projectNumber": 137,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Alien Insects"
+        "projectNumber": 137
     },
     "alienClockBot": {
-        "projectNumber": 112,
-        "coreContract": "V2",
-        "editionSize": 362,
-        "projectName": "Alien Clock"
+        "projectNumber": 112
     },
     "edificeBot": {
         "projectNumber": 204,
-        "coreContract": "V2",
-        "editionSize": 976,
-        "projectName": "Edifice",
         "namedMappings": {
           "sets": "edificeSets.json"
         }
     },
     "asemicaBot": {
-        "projectNumber": 206,
-        "coreContract": "V2",
-        "editionSize": 980,
-        "projectName": "Asemica"
+        "projectNumber": 206
     },
     "autologyBot": {
         "projectNumber": 209,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Autology",
         "namedMappings": {
           "sets": "autologySets.json",
           "singles": "autologySingles.json"
@@ -566,89 +311,47 @@
     },
     "bentBot": {
         "projectNumber": 214,
-        "coreContract": "V2",
-        "editionSize": 1023,
-        "projectName": "Bent",
         "namedMappings": {
           "sets": "bentSets.json"
         }
     },
     "gazersBot": {
-        "projectNumber": 215,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Gazers"
+        "projectNumber": 215
     },
     "reflectionBot": {
-        "projectNumber": 208,
-        "coreContract": "V2",
-        "editionSize": 100,
-        "projectName": "Reflection"
+        "projectNumber": 208
     },
     "vortexBot": {
-        "projectNumber": 225,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Vortex"
+        "projectNumber": 225
     },
     "icBot": {
-        "projectNumber": 228,
-        "coreContract": "V2",
-        "editionSize": 100,
-        "projectName": "Incomplete Control"
+        "projectNumber": 228
     },
     "pathsBot": {
-        "projectNumber": 217,
-        "coreContract": "V2",
-        "editionSize": 523,
-        "projectName": "Paths"
+        "projectNumber": 217
     },
     "glowBot": {
-        "projectNumber": 230,
-        "coreContract": "V2",
-        "editionSize": 500,
-        "projectName": "Glow"
+        "projectNumber": 230
     },
     "wraptureBot": {
-        "projectNumber": 234,
-        "coreContract": "V2",
-        "editionSize": 50,
-        "projectName": "Wrapture"
+        "projectNumber": 234
     },
     "jiometoryBot": {
-        "projectNumber": 232,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Jiometory No Compute - ジオメトリ ハ ケイサンサレマセン"
+        "projectNumber": 232
     },
     "chimeraBot": {
-        "projectNumber": 233,
-        "coreContract": "V2",
-        "editionSize": 987,
-        "projectName": "Chimera"
+        "projectNumber": 233
     },
     "cosmicReefBot": {
-        "projectNumber": 250,
-        "coreContract": "V2",
-        "editionSize": 1024,
-        "projectName": "Cosmic Reef"
+        "projectNumber": 250
     },
     "hashCrashBot": {
-        "projectNumber": 248,
-        "coreContract": "V2",
-        "editionSize": 369,
-        "projectName": "HashCrash"
+        "projectNumber": 248
     },
     "screensBot": {
-        "projectNumber": 255,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Screens"
+        "projectNumber": 255
     },
     "raptureBot": {
-        "projectNumber": 141,
-        "coreContract": "V2",
-        "editionSize": 1000,
-        "projectName": "Rapture"
+        "projectNumber": 141
     }
 }

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -110,7 +110,7 @@ class ProjectConfig {
     const projectBotConfigs = Object.entries(projectBotsJson);
 
     // This loops through all the bot configs asynchronously, gets information
-    // on the project from the Graph, and initializes the project bot.
+    // on the project from the subgraph, and initializes the project bot.
     const promises = projectBotConfigs.map(async ([botName, botParams]) => {
       const { projectNumber, namedMappings } = botParams;
       const { invocations, name, contract } = await getArtBlocksProject(projectNumber);

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -107,11 +107,11 @@ class ProjectConfig {
   */
   async buildProjectBots(projectBotsJson) {
     const projectBots = {};
-    const projectBotsConfigs = Object.entries(projectBotsJson);
+    const projectBotConfigs = Object.entries(projectBotsJson);
 
     // This loops through all the bot configs asynchronously, gets information
     // on the project from the Graph, and initializes the project bot.
-    const promises = projectBotsConfigs.map(async ([botName, botParams]) => {
+    const promises = projectBotConfigs.map(async ([botName, botParams]) => {
       const { projectNumber, namedMappings } = botParams;
       const { invocations, name, contract } = await getArtBlocksProject(projectNumber);
       projectBots[botName] = new ProjectBot({
@@ -125,7 +125,6 @@ class ProjectConfig {
 
     await Promise.all(promises);
 
-    console.log(projectBots);
     return projectBots;
   }
 

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -96,13 +96,13 @@ class ProjectConfig {
     this.channels = ProjectConfig.buildChannelHandlers(CHANNELS);
     this.chIdByName = ProjectConfig.buildChannelIDByName(this.channels);
     this.initialize();
-    setInterval(this.initialize, METADATA_REFRESH_INTERVAL_MINUTES * 60000);
   }
 
   // Initialize async aspects of the ProjectConfig
   async initialize() {
     try {
       this.projectBots = await this.buildProjectBots(PROJECT_BOTS);
+      setInterval(() => this.buildProjectBots(PROJECT_BOTS), METADATA_REFRESH_INTERVAL_MINUTES * 60000);
     } catch(err) {
       console.error(`Error while initializing ProjectBots: ${err}`);
     }

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -4,6 +4,7 @@ const ARTBOT_IS_PROD = (
   process.env.ARTBOT_IS_PROD.toLowerCase() == 'true'
 );
 console.log('ARTBOT_IS_PROD: ', ARTBOT_IS_PROD);
+// Refresh takes around one minute, so recommend setting this to 60 minutes
 const METADATA_REFRESH_INTERVAL_MINUTES =
   process.env.METADATA_REFRESH_INTERVAL_MINUTES;
 const CHANNELS = ARTBOT_IS_PROD ?

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -124,7 +124,6 @@ class ProjectConfig {
     });
 
     await Promise.all(promises);
-
     return projectBots;
   }
 

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -109,8 +109,8 @@ class ProjectConfig {
     const projectBots = {};
     const projectBotsConfigs = Object.entries(projectBotsJson);
 
-    // This loops through all the bot configs asynchronously, gets
-    // information on the project from the Graph, and initializes the bot.
+    // This loops through all the bot configs asynchronously, gets information
+    // on the project from the Graph, and initializes the project bot.
     await Promise.all(projectBotsConfigs.map(async ([botName, botParams]) => {
       const { projectNumber, namedMappings } = botParams;
       const { invocations, name, contract } = await getArtBlocksProject(projectNumber);

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -111,7 +111,7 @@ class ProjectConfig {
 
     // This loops through all the bot configs asynchronously, gets information
     // on the project from the Graph, and initializes the project bot.
-    await Promise.all(projectBotsConfigs.map(async ([botName, botParams]) => {
+    const promises = projectBotsConfigs.map(async ([botName, botParams]) => {
       const { projectNumber, namedMappings } = botParams;
       const { invocations, name, contract } = await getArtBlocksProject(projectNumber);
       projectBots[botName] = new ProjectBot({
@@ -121,7 +121,9 @@ class ProjectConfig {
         projectName: name,
         namedMappings
       });
-    }));
+    });
+
+    await Promise.all(promises);
 
     console.log(projectBots);
     return projectBots;

--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -109,9 +109,10 @@ class ProjectConfig {
   }
 
   /*
-  * This parses imported projectBots json data and returns an object with
-  * keys equal to botName, values pointing to a new instance of ProjectBot.
-  * Returned object is useful for getting project bot instances by botName.
+  * This parses imported projectBots json data and subgraph data to return 
+  * an object with keys equal to botName and values pointing to a new instance
+  * of ProjectBot. Returned object is useful for getting project bot instances
+  * by botName.
   */
   async buildProjectBots(projectBotsJson) {
     const projectBots = {};

--- a/README.md
+++ b/README.md
@@ -10,30 +10,30 @@ ArtBot is a Node.js application.  It uses the [Yarn Package Manager](https://yar
 
 * Verify you have Node.js and npm installed.  If not, you can refer to the [Node.js official page](https://nodejs.org/) to get started.
 
-```
+```bash
 node -v
 npm -v
 ```
 
 * Install Yarn Package Manager.  For detailed instructions, refer to the [Yarn official page](https://yarnpkg.com/getting-started/install).
 
-```
+```bash
 npm install -g yarn
 ```
 
 * Install the package dependencies
-```
+```bash
 yarn install
 ```
 
 * Join the a-t Discord Server
 
-Artbot is based on the [discord.js](https://discord.js.org/) package, and is exclusively concerned with processing and sending Discord messages.  If you want to be able to interact with it, joining the Artbot test Discord server is the way to go.  https://discord.gg/W6eYPpEk3a
+Artbot is based on the [discord.js](https://discord.js.org/) package, and is exclusively concerned with processing and sending Discord messages.  If you want to be able to interact with it, joining the Artbot test Discord server is the way to go.  <https://discord.gg/W6eYPpEk3a>
 
 * Set up `.env` file based on `.env.example`.
 
 * Run the application
-```
+```bash
 yarn start
 ```
 
@@ -41,11 +41,11 @@ yarn start
 
 Please check changes you made by running the linter
 
-```
+```bash
 npm install -g eslint
 eslint <YOUR_FILE.JS>
 ```
-```
+```bash
 npm install -g jsonlint
 jsonlint <YOUR_FILE.JSON>
 ```
@@ -66,7 +66,8 @@ The core engine of Artbot is built around the discord.js package.  It serves sev
 
 * OpenSea Activity Feeds
 
-  Another well known feature of artbot is its ability to parse a feed of OpenSea activity data.  There is a hidden channel in the ArtBlocks Discord that receives a raw feed of all Art Blocks OpenSea Activity data.  Artbot then takes these messages and posts the appropriate events in the correct channel.  This includes several channels on the AB Discord, as well as a few adjacent Discords, like SquiggleDAO.  This logic lives in `Utils/activityTriager.js`
+  Another well known feature of artbot is its ability to parse a feed of OpenSea activity data.  There is a hidden channel in the ArtBlocks Discord that receives a raw feed of all Art Blocks OpenSea Activity data.  Artbot then takes these messages and posts the appropriate events in the correct channel.  
+  This includes several channels on the AB Discord, as well as a few adjacent Discords, like SquiggleDAO.  This logic lives in `Utils/activityTriager.js`
 
 * SmartBot Responses
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Required Definitions:
       - (optional) key: `"namedMappings"`
         - value: object:
           - (optional) key: `"sets"`
-            - value: json file name defining single token labels; located in 'NamedMappings' directory. e.g. `ringerSingles.json`
+            - value: json filename defining single token labels; located in 'NamedMappings' directory. e.g. `ringerSingles.json`
           - (optional) key: `"singles"`
-            value: json file name defining sets of token labels; located in 'NamedMappings' directory. e.g. `ringerSets.json`
+            value: json filename defining sets of token labels; located in 'NamedMappings' directory. e.g. `ringerSets.json`
 
 Optional Definitions
 - `NamedMappings/<projectName>Singles.json`

--- a/README.md
+++ b/README.md
@@ -105,12 +105,6 @@ Required Definitions:
     - value: object:
       - key: `"projectNumber"`
         value: project ID this bot will look up tokens for
-      - key: `"coreContract"`:
-        value: "V2" for current core contract at `0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270`
-      - key: `"editionSize"`:
-        - value: maximum number of invocations allows on project
-      - key: `"projectName"`:
-        - value: Name of project
       - (optional) key: `"namedMappings"`
         - value: object:
           - (optional) key: `"sets"`


### PR DESCRIPTION
This PR modifies the artbot to get invocations, contract, and name from the subgraph vs. the config. This allows for the config language to be simplified and queries for a specific token to throw an error instead of returning undefined if that piece has not been minted yet. I do want to eventually merge FactoryBot and ProjectBot together as well as make the config language even simpler and only for naming pieces. That will be in a follow up change as I don't want to make this change too ambiguous.

Closes #142 