### PR TITLE
Adjust regex to remove (identifier: ethereum)

### DIFF
--- a/Utils/activityTriager.js
+++ b/Utils/activityTriager.js
@@ -145,7 +145,7 @@ async function triageActivityMessage(msg, bot) {
     description = description.substring(nameLineBreakIndex, lastIndex);
 
     // Remove (ethereum) from names
-    description = description.replace(/\(ethereum\)/g, '');
+    description = description.replace(/\(identifier: ethereum\)/g, '');
 
     // Replace "Owner" with "Seller"
     description = description.replace(/Owner/, 'Seller');


### PR DESCRIPTION
OpenSea changed the token identifier from (ethereum) to (identifier: ethereum) so we have to adjust our regex to remove it.

**What we're trying to parse:**
![image](https://user-images.githubusercontent.com/17088356/152604814-78cf2081-14d3-454d-80c3-0485b36689e6.png)

closes #219 