### PR TITLE
Add doodle labs project bot config

### DIFF
--- a/ProjectConfig/channels.json
+++ b/ProjectConfig/channels.json
@@ -575,6 +575,21 @@
             "default": "261" 
         }
     },
+    "880280317477404713": {
+        "name": "Doodle Labs - the-lab",
+        "projectBotHandlers": {
+            "default": "0-DOODLE",
+            "stringTriggers": {
+                "1-DOODLE": [
+                    "slider"
+                ],
+                "2-DOODLE": [
+                    "neo",
+                    "neogen"
+                ]
+            }
+        }
+    },
     "822563871473795073": {
         "name": "factory-projects"
     },


### PR DESCRIPTION
This configures art bot to respond to project queries on the Doodle Labs server in the channel called the-lab. This is a walk through of the prototype PBAB instructions for Art Bot to make sure they are solid.

#169