### PR TITLE
Add this keyword to fix crash

### DIFF
--- a/Classes/RandomBot.js
+++ b/Classes/RandomBot.js
@@ -52,7 +52,7 @@ class RandomBot {
       return;
     }
 
-    sendRandomTokenMessage(msg.channel);
+    this.sendRandomTokenMessage(msg.channel);
   }
 
   // This function takes a channel and sends a message containing a random


### PR DESCRIPTION
Accidentally forgot a this keyword causing the Art Bot to crash on a request for a random mint in ab-art-chat.