### PR TITLE
Short-circuit message handling if sent in unobserved channel

### DIFF
--- a/ProjectConfig/projectConfig.js
+++ b/ProjectConfig/projectConfig.js
@@ -203,11 +203,6 @@ class ProjectConfig {
   */
   routeProjectNumberMsg(channelID, msg) {
     const channel = this.channels[channelID];
-    if (!channel) {
-      // only occurs when # messages sent from channels not being observed
-      console.error(`Unknown channel ID: ${channelID}`);
-      return;
-    }
     const botName =
       channel.botNameFromNumberMsgContent(msg.content.toLowerCase());
     if (botName === null) {

--- a/index.js
+++ b/index.js
@@ -102,6 +102,13 @@ bot.on('message', (msg) => {
   const msgContentLowercase = msgContent.toLowerCase();
   const channelID = msg.channel.id;
 
+  // If there is not a channel ID configured where the message was sent
+  // short-circuit handling the message
+  const channel = projectConfig.channels[channelID];
+  if (!channel) {
+    return;
+  }
+
   /*
      * If the message is in the activity channel, forward the message on
      * To the appropriate sub-channel.


### PR DESCRIPTION
Note that the current functionality that ignores the channels in channels.json which will be affected by this is smartResponses, and giveways. Giving all the smart responses a once over and thinking about it I don't think there are any egregious ways this restricts where bot messages can be sent. In the worst case we can get more general and allow more channels as time goes on.

Closes #108