### PR TITLE
Change Doodle Labs channel name

### DIFF
--- a/ProjectConfig/channels.json
+++ b/ProjectConfig/channels.json
@@ -576,7 +576,7 @@
         }
     },
     "880280317477404713": {
-        "name": "Doodle Labs - the-lab",
+        "name": "doodle-labs-the-lab",
         "projectBotHandlers": {
             "default": "0-DOODLE",
             "stringTriggers": {

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ These instructions explain how to configure Art Bot to serve project data in rel
 **Example Config**
 ```json
 "880280317477404713": {
-    "name": "Doodle Labs - the-lab",
+    "name": "doodle-labs-the-lab",
     "projectBotHandlers": {
         "default": "0-DOODLE",
         "stringTriggers": {


### PR DESCRIPTION
To keep things consistent across all channels it's probably good to stick with lower case separated by dashes as they're easier to use when using `chIdByName`.