### PR TITLE
Be more descriptive on permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ These instructions explain how to configure Art Bot to serve project data in rel
 }
 ```
 
-3. Create a pull request following the configuration schema in [required configuration](#required-configuration) to set up Art Bot to listen to a relevant channel or channels.
+3. Create a pull request following the configuration schema in [required configuration](#required-configuration) to set up Art Bot to listen to a relevant channel or channels. Note that Art Bot must have the proper permissions to view whatever channel it is listening to.
 
 **Example Config**
 ```json


### PR DESCRIPTION
Art Bot was not working on the Doodle Labs server because it needed permissions to view the channels it was watching. Adding a note here to avoid future issues.