### PR TITLE
Add warning to PBAB instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ These instructions explain how to configure Art Bot to serve project data in rel
 1. Invite ArtBot to your server by clicking [here](https://discord.com/oauth2/authorize?client_id=794646394420854824&scope=bot&permissions=19520). Note that you must have the "Manage Server" permission on the desired server to invite Art Bot.
 2. As a PBAB partner you most likely have a contract of your own. To configure this you will have to follow the [optional configuration](#optional-configuration) scheme in `ProjectConfig/partnerContracts.json` by adding a new entry.
 
+> :warning: Address must be all lowercase characters
+
 **Example Config**
 
 ```json

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Here are the currently valid contract names.
             value: json filename defining sets of token labels; located in 'NamedMappings' directory. e.g. `ringerSets.json`
 - `ProjectConfig/partnerContracts.json`
   - key: contract name
-    - value: contract address
+    - value: contract address (lowercase)
 - `NamedMappings/<projectName>Singles.json`
   - json file defining trigger names for single tokens. See `ringerSingles.json` for example.
 - `NamedMappings/<projectName>Seets.json`


### PR DESCRIPTION
If the contract address is not all lowercase characters we cannot find the project in the Art Blocks subgraph.