### PR TITLE
Update RandomBot's mint #0 handling

### DIFF
--- a/Classes/RandomBot.js
+++ b/Classes/RandomBot.js
@@ -63,7 +63,7 @@ class RandomBot {
       const projectNumber = Math.floor(Math.random() * projectCount);
       console.log(`trying to look for project ${projectNumber}`);
       const projectData = await getArtBlocksProject(projectNumber);
-      if (projectData && projectData.invocations > 0) {
+      if (projectData && projectData.invocations > 1) {
         const pieceNumber = Math.floor(Math.random() * projectData.invocations);
         const tokenID = projectNumber * 1e6 + pieceNumber;
         const artBlocksResponse = await fetch(


### PR DESCRIPTION
Update `RandomBot` to only return projects with more than one token minted (`>1` vs `>=1`).

This is done for similar reasons as https://github.com/ArtBlocks/alertbot/pull/60, and continues to build on solving https://app.asana.com/0/1201517173861745/1201967395454694/f