### PR TITLE
Update ProjectBot's mint #0 handling

### DIFF
--- a/Classes/ProjectBot.js
+++ b/Classes/ProjectBot.js
@@ -46,6 +46,9 @@ class ProjectBot {
     let pieceNumber;
     if (afterTheHash[0] == "?") {
       pieceNumber = parseInt(Math.random() * this.editionSize);
+      if (pieceNumber === 0) {
+        pieceNumber = 1;
+      }
     } else {
       pieceNumber = parseInt(afterTheHash);
     }


### PR DESCRIPTION
Update `ProjectBot` to not return a mint #0 on use of the `#?` command and instead to use mint #1 in the case that mint #0 is randomly selected.

This is done for similar reasons as ArtBlocks/alertbot#60 and https://github.com/ArtBlocks/artbot/pull/251, and continues to build on solving https://app.asana.com/0/1201517173861745/1201967395454694/f