### PR TITLE
Adding active check to RandomBot

### DIFF
--- a/Classes/RandomBot.js
+++ b/Classes/RandomBot.js
@@ -25,7 +25,10 @@ class RandomBot {
   }
 
   async startRoutine(channel) {
-    setInterval(() => this.sendRandomTokenMessage(channel), RANDOM_ART_INTERVAL_MINUTES * 60000);
+    setInterval(
+      () => this.sendRandomTokenMessage(channel),
+      RANDOM_ART_INTERVAL_MINUTES * 60000
+    );
   }
 
   async initialize() {
@@ -63,7 +66,7 @@ class RandomBot {
       const projectNumber = Math.floor(Math.random() * projectCount);
       console.log(`trying to look for project ${projectNumber}`);
       const projectData = await getArtBlocksProject(projectNumber);
-      if (projectData && projectData.invocations > 1) {
+      if (projectData && projectData.invocations > 1 && projectData.active) {
         const pieceNumber = Math.floor(Math.random() * projectData.invocations);
         const tokenID = projectNumber * 1e6 + pieceNumber;
         const artBlocksResponse = await fetch(

--- a/Utils/parseArtBlocksAPI.js
+++ b/Utils/parseArtBlocksAPI.js
@@ -35,6 +35,7 @@ const contractProject = gql`
         invocations
         maxInvocations
         curationStatus
+        active
         contract {
           id
         }
@@ -145,7 +146,9 @@ async function _getContractProject(projectId, contractId) {
  * subgraph.
  */
 async function getContractProject(projectId, contractId) {
-  return !contractId ? getArtBlocksProject(projectId) : _getContractProject(projectId, contractId)
+  return !contractId
+    ? getArtBlocksProject(projectId)
+    : _getContractProject(projectId, contractId);
 }
 
 /*

--- a/Utils/parseArtBlocksAPI.js
+++ b/Utils/parseArtBlocksAPI.js
@@ -34,8 +34,8 @@ const contractProject = gql`
         name
         invocations
         maxInvocations
-        curationStatus
         active
+        curationStatus
         contract {
           id
         }


### PR DESCRIPTION
Tiny PR ensuring no non-active (AKA non-public) projects are shown by RandomBot

Currently redundant with @jakerockland 's fix here: https://github.com/ArtBlocks/artbot/commit/4e66334dae2c042b199a2998f18849ead37c62be

But this futureproofs in case we ever decide to do more than one mint for some reason

EDIT: Jk this is actually useful for when there are multiple artists like this: https://www.artblocks.io/project/297