### PR TITLE
adding color to LooksRare embeds

### DIFF
--- a/Classes/LooksRareAPIPollBot.js
+++ b/Classes/LooksRareAPIPollBot.js
@@ -17,7 +17,8 @@ class LooksRareAPIPollBot extends APIPollBot {
 	 */
   constructor(apiEndpoint, refreshRateMs, bot) {
     super(apiEndpoint, refreshRateMs, bot);
-    this.color = '#62DE7C';
+    this.listColor = '#62DE7C';
+    this.saleColor = '#9d77f7';
   }
 
   /**
@@ -56,7 +57,6 @@ class LooksRareAPIPollBot extends APIPollBot {
   async buildDiscordMessage(msg) {
     // Create embed we will be sending
     const embed = new MessageEmbed();
-    embed.setColor(this.color);
 
     // Parsing LooksRare message to get info
     const tokenID = msg.token.tokenId;
@@ -78,9 +78,11 @@ class LooksRareAPIPollBot extends APIPollBot {
       // Item sold, add 'Buyer' field
       embed.addField('Buyer', msg.to);
       priceText = 'Sale Price';
+      embed.setColor(this.saleColor);
     } else {
       // Item Listed
       priceText = 'List Price';
+      embed.setColor(this.listColor);
     }
     const price = msg.order.price;
     embed.addField(

--- a/Classes/LooksRareAPIPollBot.js
+++ b/Classes/LooksRareAPIPollBot.js
@@ -11,20 +11,21 @@ const {
 /** API Poller for LooksRare List and Sale events */
 class LooksRareAPIPollBot extends APIPollBot {
   /** Constructor just calls super
-   * @param {string} apiEndpoint - Endpoint to be hitting
-   * @param {number} refreshRateMs - How often to poll the endpoint (in ms)
-   * @param {*} bot - Discord bot that will be sending messages
-   */
+	 * @param {string} apiEndpoint - Endpoint to be hitting
+	 * @param {number} refreshRateMs - How often to poll the endpoint (in ms)
+	 * @param {*} bot - Discord bot that will be sending messages
+	 */
   constructor(apiEndpoint, refreshRateMs, bot) {
     super(apiEndpoint, refreshRateMs, bot);
+    this.color = '#62DE7C';
   }
 
   /**
-   * Parses and handles LooksRare API endpoint data
-   * Only sends events that are new
-   * Response spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
-   * @param {*} responseData - Dict parsed from API request json
-   */
+	 * Parses and handles LooksRare API endpoint data
+	 * Only sends events that are new
+	 * Response spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
+	 * @param {*} responseData - Dict parsed from API request json
+	 */
   handleAPIResponse(responseData) {
     let maxTime = 0;
     for (const data of responseData.data) {
@@ -48,13 +49,14 @@ class LooksRareAPIPollBot extends APIPollBot {
   }
 
   /**
-   * Handles constructing and sending Discord embed message
-   * LooksRare API Spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
-   * @param {*} msg - Dict of event data from API response
-   */
+	 * Handles constructing and sending Discord embed message
+	 * LooksRare API Spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
+	 * @param {*} msg - Dict of event data from API response
+	 */
   async buildDiscordMessage(msg) {
     // Create embed we will be sending
     const embed = new MessageEmbed();
+    embed.setColor(this.color);
 
     // Parsing LooksRare message to get info
     const tokenID = msg.token.tokenId;

--- a/Classes/LooksRareAPIPollBot.js
+++ b/Classes/LooksRareAPIPollBot.js
@@ -11,10 +11,10 @@ const {
 /** API Poller for LooksRare List and Sale events */
 class LooksRareAPIPollBot extends APIPollBot {
   /** Constructor just calls super
-	 * @param {string} apiEndpoint - Endpoint to be hitting
-	 * @param {number} refreshRateMs - How often to poll the endpoint (in ms)
-	 * @param {*} bot - Discord bot that will be sending messages
-	 */
+   * @param {string} apiEndpoint - Endpoint to be hitting
+   * @param {number} refreshRateMs - How often to poll the endpoint (in ms)
+   * @param {*} bot - Discord bot that will be sending messages
+   */
   constructor(apiEndpoint, refreshRateMs, bot) {
     super(apiEndpoint, refreshRateMs, bot);
     this.listColor = '#62DE7C';
@@ -22,11 +22,11 @@ class LooksRareAPIPollBot extends APIPollBot {
   }
 
   /**
-	 * Parses and handles LooksRare API endpoint data
-	 * Only sends events that are new
-	 * Response spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
-	 * @param {*} responseData - Dict parsed from API request json
-	 */
+   * Parses and handles LooksRare API endpoint data
+   * Only sends events that are new
+   * Response spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
+   * @param {*} responseData - Dict parsed from API request json
+   */
   handleAPIResponse(responseData) {
     let maxTime = 0;
     for (const data of responseData.data) {
@@ -50,10 +50,10 @@ class LooksRareAPIPollBot extends APIPollBot {
   }
 
   /**
-	 * Handles constructing and sending Discord embed message
-	 * LooksRare API Spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
-	 * @param {*} msg - Dict of event data from API response
-	 */
+   * Handles constructing and sending Discord embed message
+   * LooksRare API Spec: https://looksrare.github.io/api-docs/#/Events/EventController.getEvents
+   * @param {*} msg - Dict of event data from API response
+   */
   async buildDiscordMessage(msg) {
     // Create embed we will be sending
     const embed = new MessageEmbed();


### PR DESCRIPTION
Teeny tiny PR to add color to LooksRare embeds - just noticed the OS ones had some so decided to add em to LR ones to differentiate them more!

Currently in AB discord:
<img width="562" alt="Screen Shot 2022-05-05 at 4 17 29 PM" src="https://user-images.githubusercontent.com/18132641/167027133-df5ff010-8656-45ee-b147-4bbf23b88a76.png">

Listings now have LooksRare Green color:
<img width="446" alt="Screen Shot 2022-05-05 at 4 14 43 PM" src="https://user-images.githubusercontent.com/18132641/167026768-6ab94db3-3573-4742-a35c-cb08b89623bb.png">

Sales have the LooksRare Purple color:
<img width="455" alt="Screen Shot 2022-05-05 at 4 14 59 PM" src="https://user-images.githubusercontent.com/18132641/167026770-acd9c4f3-4394-49c4-bf55-5afd5e9129f7.png">

Went back and forth on swapping the colors, but since OS sales have Green color I went with Purple for LR sales
