### PR TITLE
Adding trade and list channels for safety messages

### DIFF
--- a/ProjectConfig/channels.json
+++ b/ProjectConfig/channels.json
@@ -701,6 +701,12 @@
     "859316381517348874": {
         "name": "squiggle-listings"
     },
+    "874066035618250752": {
+        "name": "trade-swaps"
+    },
+    "782644400084877315": {
+        "name": "for-sale-listings"
+    },
     "880937060075192320": {
         "name": "fidenza-and-ic-sales",
         "projectBotHandlers": {


### PR DESCRIPTION
## What's New
- Just adding trade-swaps and for-sale-listings channels to channels.json so that the smart bot will read messages that go in there
- Needed so that mods can use `staysafe?` command in those channels