### PR TITLE
Adding PBAB indexer (plus small fixes)

### DIFF
--- a/Classes/ArtIndexerBot.js
+++ b/Classes/ArtIndexerBot.js
@@ -1,8 +1,10 @@
+/* eslint-disable require-jsdoc */
 require('dotenv').config();
 const deburr = require('lodash.deburr');
 const Web3 = require('web3');
 const ProjectBot = require('./ProjectBot').ProjectBot;
-const getArtBlocksProjects = require('../Utils/parseArtBlocksAPI').getArtBlocksProjects;
+const getArtBlocksProjects =
+  require('../Utils/parseArtBlocksAPI').getArtBlocksProjects;
 
 const web3 = new Web3(Web3.givenProvider || 'ws://localhost:8545');
 
@@ -12,12 +14,14 @@ const METADATA_REFRESH_INTERVAL_MINUTES =
 
 class ArtIndexerBot {
   constructor(projectFetch = getArtBlocksProjects) {
-    this.projectFetch = projectFetch
+    this.projectFetch = projectFetch;
     this.projects = {};
     this.init();
   }
 
-  // Initialize async aspects of the FactoryBot
+  /**
+   * Initialize async aspects of the FactoryBot
+   */
   async init() {
     await this.buildProjectBots();
 
@@ -32,7 +36,7 @@ class ArtIndexerBot {
       for (let i = 0; i < projects.length; i++) {
         const project = projects[i];
         console.log(
-            `Refreshing project cache for Project ${project.projectId} ${project.name}`,
+          `Refreshing project cache for Project ${project.projectId} ${project.name}`
         );
 
         const newBot = new ProjectBot({
@@ -54,15 +58,21 @@ class ArtIndexerBot {
 
     if (content.length <= 1) {
       msg.channel.send(
-          `Invalid format, enter # followed by the piece number of interest.`,
+        `Invalid format, enter # followed by the piece number of interest.`
       );
       return;
     }
 
-    const afterTheHash = content.substring(1);
-    const projectKey = this.toProjectKey(
-        content.substr(content.indexOf(' ') + 1),
+    let projectKey = this.toProjectKey(
+      content.substr(content.indexOf(' ') + 1).replace('?details', '')
     );
+
+    // if '#?' message, get random project
+    // TODO: merge functionality with RandomBot
+    if (projectKey === '#?') {
+      const keys = Object.keys(this.projects);
+      projectKey = keys[Math.floor(Math.random() * keys.length)];
+    }
 
     console.log(`Searching for project ${projectKey}`);
     const projBot = this.projects[projectKey];
@@ -73,8 +83,8 @@ class ArtIndexerBot {
 
   toProjectKey(projectName) {
     const projectKey = deburr(projectName)
-        .toLowerCase()
-        .replace(/[^a-z0-9]/gi, '');
+      .toLowerCase()
+      .replace(/[^a-z0-9]/gi, '');
 
     // just in case there's a project name with no alphanumerical characters
     if (projectKey === '') {

--- a/Classes/ProjectBot.js
+++ b/Classes/ProjectBot.js
@@ -1,29 +1,38 @@
-const {
-  MessageEmbed
-} = require("discord.js");
-const fetch = require("node-fetch");
-const Web3 = require("web3");
-const { ProjectHandlerHelper } = require("./ProjectHandlerHelper");
+/* eslint-disable require-jsdoc */
+const { MessageEmbed } = require('discord.js');
+const fetch = require('node-fetch');
+const Web3 = require('web3');
+const { ProjectHandlerHelper } = require('./ProjectHandlerHelper');
 
-const web3 = new Web3(Web3.givenProvider || "ws://localhost:8545");
+const web3 = new Web3(Web3.givenProvider || 'ws://localhost:8545');
 
-const MINT_ADDRESS = "0x0000000000000000000000000000000000000000";
 const EMBED_COLOR = 0xff0000;
-const UNKNOWN_ADDRESS = "unknown";
-const UNKNOWN_USERNAME = "unknown";
+const UNKNOWN_ADDRESS = 'unknown';
+const UNKNOWN_USERNAME = 'unknown';
 
+/**
+ * Bot for handling projects
+ */
 class ProjectBot {
-  constructor({ projectNumber, coreContract, editionSize, projectName, namedMappings }) {
+  constructor({
+    projectNumber,
+    coreContract,
+    editionSize,
+    projectName,
+    namedMappings,
+  }) {
     this.projectNumber = projectNumber;
     this.coreContract = coreContract;
     this.editionSize = editionSize;
     this.projectName = projectName;
-    this.namedMappings = namedMappings ? ProjectBot.getProjectHandlerHelper(namedMappings) : null;
+    this.namedMappings = namedMappings
+      ? ProjectBot.getProjectHandlerHelper(namedMappings)
+      : null;
   }
 
   static getProjectHandlerHelper({ singles, sets }) {
-    let singlesMap = singles ? require(`../NamedMappings/${singles}`) : null;
-    let setsMap = sets ? require(`../NamedMappings/${sets}`) : null;
+    const singlesMap = singles ? require(`../NamedMappings/${singles}`) : null;
+    const setsMap = sets ? require(`../NamedMappings/${sets}`) : null;
     return new ProjectHandlerHelper(singlesMap, setsMap);
   }
 
@@ -41,10 +50,10 @@ class ProjectBot {
       content = this.namedMappings.transform(content);
     }
 
-    let detailsRequested = content.toLowerCase().includes("detail");
-    let afterTheHash = content.substring(1);
+    const detailsRequested = content.toLowerCase().includes('detail');
+    const afterTheHash = content.substring(1);
     let pieceNumber;
-    if (afterTheHash[0] == "?") {
+    if (afterTheHash[0] == '?') {
       pieceNumber = parseInt(Math.random() * this.editionSize);
     } else {
       pieceNumber = parseInt(afterTheHash);
@@ -57,45 +66,69 @@ class ProjectBot {
       return;
     }
 
-    let tokenID = pieceNumber + (this.projectNumber * 1e6);
-    let openSeaURL = `https://api.opensea.io/api/v1/asset/${this.coreContract}/${tokenID}/`;
+    const tokenID = pieceNumber + this.projectNumber * 1e6;
+    const openSeaURL = `https://api.opensea.io/api/v1/asset/${this.coreContract}/${tokenID}/`;
 
-    await fetch(
-        openSeaURL, {
-          method: "GET",
-          headers: {
-            'X-API-KEY': process.env.OPENSEA_API_KEY
-          },
-        }
-      )
+    await fetch(openSeaURL, {
+      method: 'GET',
+      headers: {
+        'X-API-KEY': process.env.OPENSEA_API_KEY,
+      },
+    })
       .then((response) => response.json())
       .then((openSeaData) => {
-        console.log(openSeaData, "OPENSEA DATA");
+        console.log(openSeaData, 'OPENSEA DATA');
         this.sendMetaDataMessage(openSeaData, msg, tokenID, detailsRequested);
       })
       .catch((err) => {
-        console.warn(`MetaData message is being sent in a degraded manner. Is OpenSea's API down? https://status.opensea.io/`);
+        console.warn(
+          `MetaData message is being sent in a degraded manner. Is OpenSea's API down? https://status.opensea.io/`
+        );
         this.sendMetaDataMessage(null, msg, tokenID, detailsRequested);
       });
   }
 
+  /**
+   * Constructs and sends discord message
+   * @param {*} openSeaData
+   * @param {*} msg
+   * @param {*} tokenID
+   * @param {*} detailsRequested
+   */
   async sendMetaDataMessage(openSeaData, msg, tokenID, detailsRequested) {
-    let artBlocksResponse = await fetch(`https://token.artblocks.io/${this.coreContract}/${tokenID}`);
-    let artBlocksData = await artBlocksResponse.json();
-    console.log(artBlocksData, "ARTBLOCKS DATA");
+    const artBlocksResponse = await fetch(
+      `https://token.artblocks.io/${this.coreContract}/${tokenID}`
+    );
+    const artBlocksData = await artBlocksResponse.json();
+    console.log(artBlocksData, 'ARTBLOCKS DATA');
     // If the OpenSea API is available use their link for the title otherwise use an AB link
-    const titleLink = openSeaData ? openSeaData.permalink : artBlocksData.external_url;
+    const titleLink = openSeaData
+      ? openSeaData.permalink
+      : artBlocksData.external_url;
 
+    let title = artBlocksData.name + ' - ' + artBlocksData.artist;
+
+    // If PBAB project, add PBAB name to front
+    if (
+      artBlocksData.platform !== '' &&
+      !artBlocksData.platform.includes('Art Blocks')
+    ) {
+      title = artBlocksData.platform + ' - ' + title;
+    }
+
+    let moreDetailsText = `Add "?details" to your ArtBot command`;
+    if (artBlocksData.external_url !== '') {
+      moreDetailsText += ` or [view on artblocks.io](${artBlocksData.external_url}).`;
+    }
     // If user did *not* request full details, return just a large image,
     // along with a link to the OpenSea page and ArtBlocks live script.
     if (!detailsRequested) {
       const imageContent = new MessageEmbed()
         // Set the title of the field.
-        .setTitle(artBlocksData.name)
+        .setTitle(title)
         // Add link to title.
         .setURL(titleLink)
-        // Add "Live Script" field.
-        .addField("Want More Info?", `Add "details" to your ArtBot command or [view on artblocks.io](${artBlocksData.external_url}).`)
+        .addField('Want More Info?', moreDetailsText)
         // Set the full image for embed.
         .setImage(artBlocksData.image);
       msg.channel.send(imageContent);
@@ -104,12 +137,15 @@ class ProjectBot {
 
     // Otherwise, return full metadata for the asset.
     const { features } = artBlocksData;
-    const assetFeatures = (!!features && Object.keys(features).length) ?
-      Object.keys(features).map(key => `${key}: ${features[key]}`).join("\n"):
-      "Not yet available.";
+    const assetFeatures =
+      !!features && Object.keys(features).length
+        ? Object.keys(features)
+            .map((key) => `${key}: ${features[key]}`)
+            .join('\n')
+        : 'Not yet available.';
     const embedContent = new MessageEmbed()
       // Set the title of the field.
-      .setTitle(artBlocksData.name)
+      .setTitle(title)
       // Add link to title.
       .setURL(titleLink)
       // Set the color of the embed.
@@ -117,87 +153,91 @@ class ProjectBot {
       // Set the main content of the embed
       .setThumbnail(artBlocksData.image)
       // Add "Live Script" field.
-      .addField("Live Script", `[view on artblocks.io](${artBlocksData.external_url})`)
+      .addField(
+        'Live Script',
+        `[view on artblocks.io](${artBlocksData.external_url})`
+      )
       // Add "Features" field.
-      .addField("Features", assetFeatures)
+      .addField('Features', assetFeatures);
 
     // If OpenSea data is available add it otherwise say we are operating in a degraded mode
     if (openSeaData) {
       embedContent
-      // Add sale number details.
-      .addField("Total Sales", this.parseNumSales(openSeaData.num_sales))
-      // Add current owner info.
-      .addFields(this.parseOwnerInfo(openSeaData.owner))
-      // Add sale info.
-      .addFields(this.parseSaleInfo(openSeaData.last_sale));
+        // Add sale number details.
+        .addField('Total Sales', this.parseNumSales(openSeaData.num_sales))
+        // Add current owner info.
+        .addFields(this.parseOwnerInfo(openSeaData.owner))
+        // Add sale info.
+        .addFields(this.parseSaleInfo(openSeaData.last_sale));
     } else {
-      embedContent.addField("Sales Info", "It seems there is a problem with the OpenSea API. Check status [here](https://status.opensea.io/).");
+      embedContent.addField(
+        'Sales Info',
+        'It seems there is a problem with the OpenSea API. Check status [here](https://status.opensea.io/).'
+      );
     }
 
     msg.channel.send(embedContent);
   }
 
   parseOwnerInfo(ownerAccount) {
-    let address = ownerAccount.address;
-    let addressPreview = address !== null ?
-      address.slice(0, 8) :
-      UNKNOWN_ADDRESS;
-    let addressOpenSeaURL = `https://opensea.io/accounts/${address}`;
-    let ownerUsername = ownerAccount.user !== null ?
-      ownerAccount.user.username :
-      UNKNOWN_USERNAME;
+    const address = ownerAccount.address;
+    const addressPreview =
+      address !== null ? address.slice(0, 8) : UNKNOWN_ADDRESS;
+    const addressOpenSeaURL = `https://opensea.io/accounts/${address}`;
+    let ownerUsername =
+      ownerAccount.user !== null
+        ? ownerAccount.user.username
+        : UNKNOWN_USERNAME;
     if (ownerUsername === null) {
       ownerUsername = UNKNOWN_USERNAME;
     }
 
     return {
-      name: "Owner",
+      name: 'Owner',
       value: `[${addressPreview}](${addressOpenSeaURL}) (${ownerUsername})`,
       inline: true,
     };
   }
 
   parseSaleInfo(saleInfo) {
-    if (saleInfo !== null && saleInfo.event_type == "successful") {
-      let eventDate = new Date(saleInfo.created_date).toLocaleDateString();
-      let sellerAccount = saleInfo.transaction.to_account;
+    if (saleInfo !== null && saleInfo.event_type == 'successful') {
+      const eventDate = new Date(saleInfo.created_date).toLocaleDateString();
+      const sellerAccount = saleInfo.transaction.to_account;
       let sellerAddress;
       let sellerAddressPreview;
       let sellerUsername;
       if (sellerAccount !== null) {
         sellerAddress = sellerAccount.address;
-        sellerAddressPreview = sellerAddress !== null ?
-          sellerAddress.slice(0, 8) :
-          UNKNOWN_ADDRESS;
-        sellerUsername = sellerAccount.user !== null ?
-          sellerAccount.user.username :
-          UNKNOWN_USERNAME;
+        sellerAddressPreview =
+          sellerAddress !== null ? sellerAddress.slice(0, 8) : UNKNOWN_ADDRESS;
+        sellerUsername =
+          sellerAccount.user !== null
+            ? sellerAccount.user.username
+            : UNKNOWN_USERNAME;
         if (sellerUsername === null) {
           sellerUsername = UNKNOWN_USERNAME;
         }
       }
 
       return {
-        name: "Last Sale",
+        name: 'Last Sale',
         value: `Sold for ${web3.utils.fromWei(
-                saleInfo.total_price,
-                "ether"
-              )}Ξ by [${sellerAddressPreview}](https://opensea.io/accounts/${
-                      sellerAddress
-                    }) (${sellerUsername}) on ${eventDate}`,
+          saleInfo.total_price,
+          'ether'
+        )}Ξ by [${sellerAddressPreview}](https://opensea.io/accounts/${sellerAddress}) (${sellerUsername}) on ${eventDate}`,
         inline: true,
       };
     }
     return {
-      name: "Last Sale",
-      value: "N/A",
+      name: 'Last Sale',
+      value: 'N/A',
       inline: true,
     };
   }
 
   parseNumSales(numSales) {
     if (numSales == 0) {
-      return "None";
+      return 'None';
     }
     return `${numSales}`;
   }

--- a/Utils/parseArtBlocksAPI.js
+++ b/Utils/parseArtBlocksAPI.js
@@ -1,18 +1,18 @@
-const parse = require("node-html-parser").parse;
-const fetch = require("node-fetch");
-const { createClient, gql } = require("@urql/core");
+const parse = require('node-html-parser').parse;
+const fetch = require('node-fetch');
+const {createClient, gql} = require('@urql/core');
 
-const API_URL = "https://api.thegraph.com/subgraphs/name/artblocks/art-blocks";
+const API_URL = 'https://api.thegraph.com/subgraphs/name/artblocks/art-blocks';
 
 // core contract addresses to include during initilization
-const CORE_CONTRACTS = require("../ProjectConfig/coreContracts.json");
+const CORE_CONTRACTS = require('../ProjectConfig/coreContracts.json');
 
 const client = createClient({
   url: API_URL,
   fetch: fetch,
   fetchOptions: () => ({
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
   }),
 });
@@ -28,17 +28,9 @@ const contractProjectsMinimal = gql`
 `;
 
 const contractProjects = gql`
-  query getContractProjects(
-    $id: ID!
-    $first: Int!
-    $skip: Int
-  ) {
+  query getContractProjects($id: ID!, $first: Int!, $skip: Int) {
     contract(id: $id) {
-      projects(
-        first: $first
-        skip: $skip
-        orderBy: projectId
-      ) {
+      projects(first: $first, skip: $skip, orderBy: projectId) {
         projectId
         name
         invocations
@@ -96,6 +88,14 @@ const contractProjectsWithCurationStatus = gql`
   }
 `;
 
+const getPBABContracts = gql`
+  query getPBABContracts($ids: [ID]!) {
+    contracts(where: { id_not_in: $ids }) {
+      id
+    }
+  }
+`;
+
 /*
  * helper function to get project count of a single
  * art blocks contract (uses pagination)
@@ -107,12 +107,12 @@ async function _getContractProjectCount(contractId) {
     let totalProjects = 0;
     while (true) {
       const result = await client
-        .query(contractProjectsMinimal, {
-          id: contractId,
-          first: maxProjectsPerQuery,
-          skip: totalProjects,
-        })
-        .toPromise();
+          .query(contractProjectsMinimal, {
+            id: contractId,
+            first: maxProjectsPerQuery,
+            skip: totalProjects,
+          })
+          .toPromise();
       const numResults = result.data.contract.projects.length;
       totalProjects += numResults;
       if (numResults !== maxProjectsPerQuery) {
@@ -150,14 +150,14 @@ async function getArtBlocksProjectCount() {
 async function _getContractProject(projectId, contractId) {
   try {
     const result = await client
-      .query(contractProject, {
-        id: contractId,
-        projectId: projectId,
-      })
-      .toPromise();
-    return result.data.contract.projects.length > 0
-      ? result.data.contract.projects[0]
-      : null;
+        .query(contractProject, {
+          id: contractId,
+          projectId: projectId,
+        })
+        .toPromise();
+    return result.data.contract.projects.length > 0 ?
+      result.data.contract.projects[0] :
+      null;
   } catch (err) {
     console.error(err);
     return undefined;
@@ -171,12 +171,12 @@ async function _getContractProject(projectId, contractId) {
  * subgraph.
  */
 async function getContractProject(projectId, contractId) {
-  return !contractId
-    ? getArtBlocksProject(projectId)
-    : _getContractProject(projectId, contractId);
+  return !contractId ?
+    getArtBlocksProject(projectId) :
+    _getContractProject(projectId, contractId);
 }
 
-/*
+/**
  * get data for a flagship artblocks project
  * Returns undefined if no project found (errors or DNE).
  * If project found, returns object with:
@@ -187,12 +187,13 @@ async function getContractProject(projectId, contractId) {
  *   - projectId
  *   - contract
  *     - id: string Contract Address
+ * @param {*} projectNumber
  */
 async function getArtBlocksProject(projectNumber) {
   try {
     const contractsToGet = Object.values(CORE_CONTRACTS);
     const promises = contractsToGet.map(
-      _getContractProject.bind(null, projectNumber)
+        _getContractProject.bind(null, projectNumber),
     );
     const project = await Promise.all(promises);
     // return the element that is not null and not undefined
@@ -203,9 +204,10 @@ async function getArtBlocksProject(projectNumber) {
   return undefined;
 }
 
-/*
+/**
  * helper function to get factory projects of a single
  * art blocks contract (uses pagination)
+ * @param {*} contractId
  */
 async function _getContractFactoryProjects(contractId) {
   // max returned projects in a single query
@@ -214,13 +216,13 @@ async function _getContractFactoryProjects(contractId) {
     const factoryProjects = [];
     while (true) {
       const result = await client
-        .query(contractProjectsWithCurationStatus, {
-          id: contractId,
-          first: maxProjectsPerQuery,
-          skip: factoryProjects.length,
-          curationStatus: "factory",
-        })
-        .toPromise();
+          .query(contractProjectsWithCurationStatus, {
+            id: contractId,
+            first: maxProjectsPerQuery,
+            skip: factoryProjects.length,
+            curationStatus: 'factory',
+          })
+          .toPromise();
       factoryProjects.push(...result.data.contract.projects);
       if (result.data.contract.projects.length !== maxProjectsPerQuery) {
         break;
@@ -233,9 +235,10 @@ async function _getContractFactoryProjects(contractId) {
   }
 }
 
-/*
+/**
  * helper function to gets all projects of a single
  * art blocks contract (uses pagination)
+ * @param {*} contractId
  */
 async function _getContractProjects(contractId) {
   // max returned projects in a single query
@@ -244,12 +247,12 @@ async function _getContractProjects(contractId) {
     const allProjects = [];
     while (true) {
       const result = await client
-        .query(contractProjects, {
-          id: contractId,
-          first: maxProjectsPerQuery,
-          skip: allProjects.length,
-        })
-        .toPromise();
+          .query(contractProjects, {
+            id: contractId,
+            first: maxProjectsPerQuery,
+            skip: allProjects.length,
+          })
+          .toPromise();
       allProjects.push(...result.data.contract.projects);
       if (result.data.contract.projects.length !== maxProjectsPerQuery) {
         break;
@@ -266,7 +269,7 @@ async function _getContractProjects(contractId) {
  * the AB subgraph curation status is null for recent projects and is slow to update
  * workaround by querying AB api for curation status
  */
-const AB_TOKEN_API_URL = "https://token.artblocks.io/";
+const AB_TOKEN_API_URL = 'https://token.artblocks.io/';
 const curationStatusCache = {};
 async function _getContractNullFactoryProjects(contractId) {
   // max returned projects in a single query
@@ -275,35 +278,35 @@ async function _getContractNullFactoryProjects(contractId) {
     const nullProjects = [];
     while (true) {
       const result = await client
-        .query(contractProjectsWithCurationStatus, {
-          id: contractId,
-          first: maxProjectsPerQuery,
-          skip: nullProjects.length,
-          curationStatus: null,
-        })
-        .toPromise();
+          .query(contractProjectsWithCurationStatus, {
+            id: contractId,
+            first: maxProjectsPerQuery,
+            skip: nullProjects.length,
+            curationStatus: null,
+          })
+          .toPromise();
       nullProjects.push(...result.data.contract.projects);
       if (result.data.contract.projects.length !== maxProjectsPerQuery) {
         break;
       }
     }
     const curationStatus = await Promise.all(
-      nullProjects.map(async (nullProject) => {
-        if (nullProject.projectId in curationStatusCache) {
-          return curationStatusCache[nullProject.projectId];
-        }
+        nullProjects.map(async (nullProject) => {
+          if (nullProject.projectId in curationStatusCache) {
+            return curationStatusCache[nullProject.projectId];
+          }
 
-        const tokenResponse = await fetch(
-          AB_TOKEN_API_URL + nullProject.projectId * 1e6
-        );
-        const token = await tokenResponse.json();
+          const tokenResponse = await fetch(
+              AB_TOKEN_API_URL + nullProject.projectId * 1e6,
+          );
+          const token = await tokenResponse.json();
 
-        curationStatusCache[nullProject.projectId] = token.curation_status;
-        return token.curation_status;
-      })
+          curationStatusCache[nullProject.projectId] = token.curation_status;
+          return token.curation_status;
+        }),
     );
     const nullFactoryProjects = nullProjects.filter(
-      (_, i) => curationStatus[i] === "factory"
+        (_, i) => curationStatus[i] === 'factory',
     );
     return nullFactoryProjects;
   } catch (err) {
@@ -312,7 +315,7 @@ async function _getContractNullFactoryProjects(contractId) {
   }
 }
 
-/*
+/**
  * get data for all flagship artblocks factory projects
  * Returns undefined if errors encountered while fetching.
  * If project found, returns array of project objects with:
@@ -337,7 +340,7 @@ async function getArtBlocksFactoryProjects() {
   return undefined;
 }
 
-/*
+/**
  * get data for all artblocks projects
  * Returns undefined if errors encountered while fetching.
  * If project found, returns array of project objects with:
@@ -361,8 +364,51 @@ async function getArtBlocksProjects() {
   return undefined;
 }
 
+/**
+ * gets all PBAB Contracts from Hasura
+ *
+ */
+async function _getPBABContracts() {
+  try {
+    const result = await client
+        .query(getPBABContracts, {
+          ids: Object.values(CORE_CONTRACTS),
+        })
+        .toPromise();
+    return result.data.contracts.map(({id}) => id);
+  } catch (err) {
+    console.error(err);
+    return undefined;
+  }
+}
+
+/**
+ * get data for all PBAB Projects
+ * Returns undefined if errors encountered while fetching.
+ * If project found, returns array of project objects with:
+ *   - invocations
+ *   - maxInvocations
+ *   - name
+ *   - projectId
+ *   - contract
+ *     - id: string Contract Address
+ */
+async function getPBABProjects() {
+  try {
+    const contractsToGet = await _getPBABContracts();
+    const allArrays = await Promise.all([
+      ...contractsToGet.map(_getContractProjects),
+    ]);
+    return allArrays.flat();
+  } catch (err) {
+    console.error(err);
+  }
+  return undefined;
+}
+
 module.exports.getArtBlocksProject = getArtBlocksProject;
 module.exports.getArtBlocksFactoryProjects = getArtBlocksFactoryProjects;
 module.exports.getArtBlocksProjects = getArtBlocksProjects;
+module.exports.getPBABProjects = getPBABProjects;
 module.exports.getArtBlocksProjectCount = getArtBlocksProjectCount;
 module.exports.getContractProject = getContractProject;

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const CORE_CONTRACTS = require('./ProjectConfig/coreContracts.json');
 const {LooksRareAPIPollBot} = require('./Classes/LooksRareAPIPollBot');
 // Special handlers.
 const {triageActivityMessage} = require('./Utils/activityTriager');
+const {getPBABProjects} = require('./Utils/parseArtBlocksAPI');
 
 const smartBotResponse = require('./Utils/smartBotResponse').smartBotResponse;
 const handleGiveawayMessage =
@@ -117,6 +118,8 @@ bot.giveawaysManager.on('giveawayEnded', (giveaway, winners) => {
 
 const factoryParty = new ArtIndexerBot(getArtBlocksFactoryProjects);
 const artIndexerBot = new ArtIndexerBot();
+// TODO: uncomment once PBAB-block-talk channel created
+// const pbabIndexerBot = new ArtIndexerBot(getPBABProjects);
 const randomGuy = new RandomBot();
 
 // Special address collector.
@@ -170,6 +173,10 @@ bot.on('message', (msg) => {
       case CHANNEL_BLOCK_TALK:
         artIndexerBot.handleNumberMessage(msg);
         break;
+      // TODO: Uncomment once PBAB Channel available
+      // case CHANNEL_PBAB_TALK:
+      //   pbabIndexerBot.handleNumberMessage(msg);
+      //   break;
       case CHANNEL_ART_CHAT:
         randomGuy.handleRandomMessage(msg);
         break;


### PR DESCRIPTION
## What's New
- Adding ArtIndexBot support for PBAB projects (for future PBAB channel, see https://app.asana.com/0/1201517173861745/1202292292892976/f)
-- Not live yet, added TODOs for uncommenting once we have PBAB channel
-- Added Graph query to get all PBAB contracts, then used existing code to get all projects for those contracts
-- The rest is pretty much handled by Alex's great ArtIndexer code :)
- Fixed a bug I stumbled upon where you couldn't use ArtIndexer to ask for details
- Added '#?' to ArtIndexer to get random project random token
- Minor embed formatting things
-- Added Artist Name to title
-- PBAB titles formatted like: <PBAB Project Name> - <Token name> - <Artist>
-- Some PBAB projects don't have external links for some reason. If that is the case, don't include link to token page

## Screenshots of new formatting
Normal PBAB Project
<img width="494" alt="Screen Shot 2022-05-20 at 2 19 42 PM" src="https://user-images.githubusercontent.com/18132641/169589279-fe077948-1080-45d3-989f-90577966ca4a.png">

PBAB with no link
<img width="457" alt="Screen Shot 2022-05-20 at 2 20 31 PM" src="https://user-images.githubusercontent.com/18132641/169589495-d33d7427-1beb-432f-aa49-e165398892ab.png">

AB with artist
<img width="442" alt="Screen Shot 2022-05-20 at 2 20 43 PM" src="https://user-images.githubusercontent.com/18132641/169589499-83637d9f-d4a7-4dfb-a450-ecdb736c8be3.png">

## Still TODO
- Once PBAB channel is available, add to the config and uncomment
- Refactor to combine ArtIndexer and RandomBot (as they now do pretty much the same thing)