### PR TITLE
Adding null check

### DIFF
--- a/Classes/ProjectBot.js
+++ b/Classes/ProjectBot.js
@@ -109,6 +109,7 @@ class ProjectBot {
 
     // If PBAB project, add PBAB name to front
     if (
+      artBlocksData.platform &&
       artBlocksData.platform !== '' &&
       !artBlocksData.platform.includes('Art Blocks')
     ) {


### PR DESCRIPTION
## What's New
- Artbot crashed this morning due to some project it was trying to query having no '.platform' field - just adding a simple null check to prevent this from happening again

Screenshot of the logs from today's crash
<img width="929" alt="Screen Shot 2022-06-13 at 12 06 37 PM" src="https://user-images.githubusercontent.com/18132641/173408331-21e7db81-6c4a-4fa6-9a7a-58d512bebb0f.png">
