### PR TITLE
Archipelago bot: don't show PBAB trades

### DIFF
--- a/Classes/ArchipelagoBot.js
+++ b/Classes/ArchipelagoBot.js
@@ -11,6 +11,8 @@ const {
 
 const WEB_SOCKET_URL = 'wss://api.archipelago.art/ws'
 const COLLECTIONS_API = 'https://api.archipelago.art/v1/market/collections'
+const AB_LEGACY_CONTRACT = '0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a'
+const AB_STANDARD_CONTRACT = '0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270'
 const HEADERS = { 'User-Agent': 'artbot/1.0' }
 const ONE_MILLION = 1000000
 const ARCHIPELAGO_GOLD = '#9C814B'
@@ -61,6 +63,12 @@ class ArchipelagoBot {
     if (collection == null) {
       return null
     }
+    if (
+      collection.tokenContract !== AB_STANDARD_CONTRACT &&
+      collection.tokenContract !== AB_LEGACY_CONTRACT
+    ) {
+      return null
+    }
     const offset = collection.artblocksProjectIndex * ONE_MILLION
     const tokenId = offset + tokenIndex
     const artBlocksResponse = await fetch(
@@ -76,7 +84,7 @@ class ArchipelagoBot {
   async sendAskEmbed({ asker: seller, price, slug, tokenIndex }) {
     const artBlocksData = await this.getArtBlocksData(slug, tokenIndex)
     if (artBlocksData == null) {
-      console.warn(`Unable to get ArtBlocks data for ${slug} #${tokenIndex}`)
+      console.log(`Unable to get ArtBlocks data for ${slug} #${tokenIndex}`)
       return
     }
     if (BAN_ADDRESSES.has(seller)) {

--- a/Classes/ArchipelagoBot.js
+++ b/Classes/ArchipelagoBot.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch')
 const ReconnectingWebsocket = require('reconnecting-websocket')
 const WS = require('ws')
 const { MessageEmbed } = require('discord.js')
+const CORE_CONTRACTS = require('../ProjectConfig/coreContracts.json')
 
 const {
   sendEmbedToSaleChannels,
@@ -11,8 +12,6 @@ const {
 
 const WEB_SOCKET_URL = 'wss://api.archipelago.art/ws'
 const COLLECTIONS_API = 'https://api.archipelago.art/v1/market/collections'
-const AB_LEGACY_CONTRACT = '0x059EDD72Cd353dF5106D2B9cC5ab83a52287aC3a'
-const AB_STANDARD_CONTRACT = '0xa7d8d9ef8D8Ce8992Df33D8b8CF4Aebabd5bD270'
 const HEADERS = { 'User-Agent': 'artbot/1.0' }
 const ONE_MILLION = 1000000
 const ARCHIPELAGO_GOLD = '#9C814B'
@@ -64,8 +63,8 @@ class ArchipelagoBot {
       return null
     }
     if (
-      collection.tokenContract !== AB_STANDARD_CONTRACT &&
-      collection.tokenContract !== AB_LEGACY_CONTRACT
+      collection.tokenContract.toLowerCase() !== CORE_CONTRACTS.OG &&
+      collection.tokenContract.toLowerCase() !== CORE_CONTRACTS.V2
     ) {
       return null
     }


### PR DESCRIPTION
This seems consistent with ArtBot (can't find any Parnassus sales in
block talk, etc)
