### PR TITLE
Adding WETH to reservoir poller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       - run:
           name: Run application
           command: |
+            export TEST_MODE=true &&
             timeout 2m yarn start || ( [[ $? -eq 124 ]] && echo "WARNING: Timeout reached, but that's OK" )
       - run:
           name: Run Tests

--- a/Classes/APIBots/ReservoirSaleBot.js
+++ b/Classes/APIBots/ReservoirSaleBot.js
@@ -85,7 +85,9 @@ class ReservoirSaleBot extends APIPollBot {
     const buyerProfile = baseABProfile + msg.to
     embed.addField(`Seller (${platform})`, `[${sellerText}](${sellerProfile})`)
     embed.addField('Buyer', `[${buyerText}](${buyerProfile})`)
-    embed.addField(priceText, price + 'ETH', true)
+
+    const currency = msg.orderSide === 'bid' ? 'WETH' : 'ETH'
+    embed.addField(priceText, price + currency, true)
 
     // Get Art Blocks metadata response for the item.
     const tokenUrl =


### PR DESCRIPTION
## What's New
- If WETH bid wins, sale will now say "WETH" instead of "ETH"
- Adding TEST_MODE setting in circleci to prevent API pollers from running in circleci test build