### PR TITLE
Duplicate Sales/Listings fix

### DIFF
--- a/Classes/APIBots/ReservoirListBot.js
+++ b/Classes/APIBots/ReservoirListBot.js
@@ -18,7 +18,7 @@ class ReservoirListBot extends APIPollBot {
     this.contract = contract
     this.listColor = '#407FDB'
     this.saleColor = '#62DE7C'
-    this.lastUpdatedTime = (this.lastUpdatedTime / 1000).toFixed()
+    this.lastUpdatedTime = this.lastUpdatedTime.toFixed()
   }
 
   /**

--- a/Classes/APIBots/ReservoirSaleBot.js
+++ b/Classes/APIBots/ReservoirSaleBot.js
@@ -19,6 +19,7 @@ class ReservoirSaleBot extends APIPollBot {
     super(apiEndpoint, refreshRateMs, bot, headers)
     this.contract = contract
     this.lastUpdatedTime = (this.lastUpdatedTime / 1000).toFixed()
+    this.saleIds = new Set()
   }
 
   /**
@@ -31,9 +32,10 @@ class ReservoirSaleBot extends APIPollBot {
     let maxTime = 0
     for (const data of responseData.sales) {
       const eventTime = data.timestamp
-      // Only deal with event if it is new
-      if (this.lastUpdatedTime < eventTime) {
+      // Only deal with event if it is new and unique saleId
+      if (this.lastUpdatedTime < eventTime && !this.saleIds.has(data.saleId)) {
         this.buildDiscordMessage(data)
+        this.saleIds.add(data.saleId)
       }
 
       // Save the time of the latest event from this batch


### PR DESCRIPTION
## What's New
- Due to reorgs, Reservoir would sometimes report sales twice - this is fixed with a new SaleId field they just added to the api this morning. Adding a Set to the Poller to prevent duplicate sale reports
- Accidentally left a bug in where the first 50 listings would automatically send each restart no matter what. Fixed that!