### PR TITLE
Changing randombot functionality

### DIFF
--- a/Classes/ArtIndexerBot.js
+++ b/Classes/ArtIndexerBot.js
@@ -11,7 +11,14 @@ const web3 = new Web3(Web3.givenProvider || 'ws://localhost:8545')
 // Refresh takes around one minute, so recommend setting this to 60 minutes
 const METADATA_REFRESH_INTERVAL_MINUTES =
   process.env.METADATA_REFRESH_INTERVAL_MINUTES
-const RANDOM_ART_INTERVAL_MINUTES = process.env.RANDOM_ART_INTERVAL_MINUTES
+
+// RandomBot Stuff
+const RANDOM_ART_AMOUNT = 10
+const RANDOM_ART_TIME = new Date()
+RANDOM_ART_TIME.setHours(8)
+RANDOM_ART_TIME.setMinutes(0)
+RANDOM_ART_TIME.setSeconds(0)
+RANDOM_ART_TIME.setMilliseconds(0)
 
 class ArtIndexerBot {
   constructor(projectFetch = getArtBlocksProjects) {
@@ -100,22 +107,36 @@ class ArtIndexerBot {
     let msg = {}
     msg.content = '#?'
     msg.channel = channel
-    setInterval(
-      () => this.sendRandomProjectRandomTokenMessage(msg),
-      RANDOM_ART_INTERVAL_MINUTES * 60000
-    )
+    // Try to message(s) in #ab-art-chat every minute
+    setInterval(() => this.sendRandomProjectRandomTokenMessage(msg), 1 * 60000)
   }
 
   // This function takes a channel and sends a message containing a random
   // token from a random project
   async sendRandomProjectRandomTokenMessage(msg) {
+    let now = new Date()
+    // Only send message if hour and minute match up with specified time
+    if (
+      now.getHours() !== RANDOM_ART_TIME.getHours() ||
+      now.getMinutes() !== RANDOM_ART_TIME.getMinutes()
+    ) {
+      return
+    }
+
     let attempts = 0
     while (attempts < 10) {
       const keys = Object.keys(this.projects)
       let projectKey = keys[Math.floor(Math.random() * keys.length)]
       let projBot = this.projects[projectKey]
       if (projBot && projBot.editionSize > 1 && projBot.projectActive) {
-        return projBot.handleNumberMessage(msg)
+        console.log(
+          `Sending ${RANDOM_ART_AMOUNT} random pieces for ${projectKey}!`
+        )
+
+        for (let i = 0; i < RANDOM_ART_AMOUNT; i++) {
+          projBot.handleNumberMessage(msg)
+        }
+        return
       }
       attempts++
     }


### PR DESCRIPTION
## What's New
- As requested by community team, this PR changes the RandomBot functionality in #ab-art-chat to post 10 random pieces from one random collection at 8 am every day, instead of posting a random piece every hour
- This is a bit hacky but javascript is annoying so only way i could think to do it
- try to run random send function every minute - function exits if hour and minute do not match up with specified time (currently 8:00 AM)