### PR TITLE
Adding project aliases

### DIFF
--- a/Classes/ArtIndexerBot.js
+++ b/Classes/ArtIndexerBot.js
@@ -12,6 +12,7 @@ const getProjectsCurationStatus =
   require('../Utils/parseArtBlocksAPI').getProjectsCurationStatus
 
 const web3 = new Web3(Web3.givenProvider || 'ws://localhost:8545')
+const PROJECT_ALIASES = require('../ProjectConfig/project_aliases.json')
 
 // Refresh takes around one minute, so recommend setting this to 60 minutes
 const METADATA_REFRESH_INTERVAL_MINUTES =
@@ -108,6 +109,10 @@ class ArtIndexerBot {
     let projectKey = this.toProjectKey(
       content.substr(content.indexOf(' ') + 1).replace('?details', '')
     )
+
+    if (PROJECT_ALIASES[projectKey]) {
+      projectKey = this.toProjectKey(PROJECT_ALIASES[projectKey])
+    }
 
     // if '#?' message, get random project
     if (projectKey === '#?') {

--- a/ProjectConfig/project_aliases.json
+++ b/ProjectConfig/project_aliases.json
@@ -1,0 +1,9 @@
+{
+  "80spop": "80s Pop Variety Pack - for experts only 🕹",
+  "fitymi": "fake it till you make it",
+  "acofr": "Ancient Courses of Fictional Rivers",
+  "jio": "Jiometory No Compute - ジオメトリ ハ ケイサンサレマセン",
+  "fragments": "Fragments of an Infinite Field",
+  "70spopghost": "70s Pop Ghost Bonus Pack 👻",
+  "70spopsummertime": "70s Pop Super Fun Summertime Bonus Pack 🍸"
+}


### PR DESCRIPTION
## What's New
- Project Aliases for artbot (e.g. `#? 80s pop` instead of `#? 80s Pop Variety Pack - for experts only 🕹`)
- Added a few more for longer / inconvenient project names
- This is a feature I've been thinking about for a bit, but today's drop really needs it