### PR TITLE
adding new aliases

### DIFF
--- a/ProjectConfig/project_aliases.json
+++ b/ProjectConfig/project_aliases.json
@@ -4,6 +4,11 @@
   "acofr": "Ancient Courses of Fictional Rivers",
   "jio": "Jiometory No Compute - ジオメトリ ハ ケイサンサレマセン",
   "fragments": "Fragments of an Infinite Field",
+  "frags": "Fragments of an Infinite Field",
   "70spopghost": "70s Pop Ghost Bonus Pack 👻",
-  "70spopsummertime": "70s Pop Super Fun Summertime Bonus Pack 🍸"
+  "70spopsummertime": "70s Pop Super Fun Summertime Bonus Pack 🍸",
+  "aka": "Alan Ki Aankhen",
+  "hams": "sail-o-bots",
+  "seahams": "sail-o-bots",
+  "cryptocountries": "CryptoCountries: The Unpublished Archives of a Mythical World Traveler"
 }


### PR DESCRIPTION
## What's New
- Post `CryptoCountries: The Unpublished Archives of a Mythical World Traveler` drop, adding an alias for it, plus a few other community suggested ones