### PR TITLE
Adding named tokens / sets list

### DIFF
--- a/Classes/ProjectBot.js
+++ b/Classes/ProjectBot.js
@@ -54,6 +54,10 @@ class ProjectBot {
 
     // decode any mappings
     if (this.namedMappings) {
+      if (content.toLowerCase().includes('named')) {
+        msg.channel.send(this.namedMappings.listMappings())
+        return
+      }
       content = this.namedMappings.transform(content)
     }
 

--- a/Classes/ProjectHandlerHelper.js
+++ b/Classes/ProjectHandlerHelper.js
@@ -1,7 +1,37 @@
+const { MessageEmbed } = require('discord.js')
 class ProjectHandlerHelper {
   constructor(singles, sets) {
     this.singles = singles
     this.sets = sets
+  }
+
+  listMappings() {
+    let singles = ''
+    let sets = ''
+    if (this.singles) {
+      for (const [singleName] of Object.entries(this.singles)) {
+        singles += `${singleName}
+      `
+      }
+    }
+
+    if (this.sets) {
+      for (const [setName] of Object.entries(this.sets)) {
+        sets += `${setName}
+      `
+      }
+    }
+
+    return (
+      new MessageEmbed()
+        // Set the title of the field.
+        .setTitle('Available Named Pieces / Sets')
+        .setDescription(
+          'These are special tokens or sets of tokens that have been given a name by the community! Try them out here with `#<token>` or `#? <set>'
+        )
+        .addField('Tokens', singles)
+        .addField('Sets', sets)
+    )
   }
 
   transform(messageContent) {

--- a/Classes/ProjectHandlerHelper.js
+++ b/Classes/ProjectHandlerHelper.js
@@ -27,7 +27,7 @@ class ProjectHandlerHelper {
         // Set the title of the field.
         .setTitle('Available Named Pieces / Sets')
         .setDescription(
-          'These are special tokens or sets of tokens that have been given a name by the community! Try them out here with `#<token>` or `#? <set>'
+          'These are special tokens or sets of tokens that have been given a name by the community! Try them out here with `#<token>` or `#? <set>`'
         )
         .addField('Tokens', singles)
         .addField('Sets', sets)


### PR DESCRIPTION
## What's New
- Handy command (`#named`) to print out all available named tokens / sets in a curated project

<img width="632" alt="Screen Shot 2022-09-22 at 5 08 00 PM" src="https://user-images.githubusercontent.com/18132641/191866770-fb904bbf-e9ff-42a9-93be-a5ed774a7422.png">
