### PR TITLE
adding wallet vertical functionality

### DIFF
--- a/Classes/APIBots/utils.js
+++ b/Classes/APIBots/utils.js
@@ -71,7 +71,12 @@ function isWallet(msg) {
   return msg.startsWith('0x') || msg.endsWith('eth')
 }
 
+function isVerticalName(msg) {
+  return msg === 'curated' || msg === 'factory' || msg === 'playground'
+}
+
 module.exports.ensOrAddress = ensOrAddress
 module.exports.getOSName = getOSName
 module.exports.resolveEnsName = resolveEnsName
 module.exports.isWallet = isWallet
+module.exports.isVerticalName = isVerticalName

--- a/Utils/parseArtBlocksAPI.js
+++ b/Utils/parseArtBlocksAPI.js
@@ -32,7 +32,7 @@ const getAllProjectsCurationStatus = gql`
   query getAllProjectsCurationStatus($first: Int!, $skip: Int) {
     projects_metadata(limit: $first, offset: $skip) {
       id
-      curation_status_display
+      vertical_name
     }
   }
 `
@@ -595,7 +595,7 @@ async function getProjectsCurationStatus() {
     }
     const curationMapping = {}
     allProjects.forEach((proj) => {
-      curationMapping[proj.id] = proj.curation_status_display.toLowerCase()
+      curationMapping[proj.id] = proj.vertical_name.toLowerCase()
     })
     return curationMapping
   } catch (err) {


### PR DESCRIPTION
Adding functionality for `#? <wallet> <vertical_name>`

Needed to update hasura query to get the vertical name field, as curation_status_display doesn't seem to be maintained anymore