### PR TITLE
Adding Etherscan api key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ OPENSEA_API_KEY=<contact maintainer for artbot-jr if token is desired>
 RANDOM_ART_INTERVAL_MINUTES=20
 RESERVOIR_API_KEY=<contact maintainer for artbot-jr if token is desired>
 TOKEN=<contact maintainer for artbot-jr if token is desired>
+ETHERSCAN_API_KEY=<contact maintainer for artbot-jr if token is desired>

--- a/Classes/APIBots/utils.js
+++ b/Classes/APIBots/utils.js
@@ -1,7 +1,11 @@
+require('dotenv').config()
 const ethers = require('ethers')
 const fetch = require('node-fetch')
 
-let provider = new ethers.providers.AlchemyProvider('homestead')
+let provider = new ethers.providers.EtherscanProvider(
+  'homestead',
+  process.env.ETHERSCAN_API_KEY
+)
 
 // Runtime ENS cache just to limit queries
 let ensAddressMap = {}


### PR DESCRIPTION
## What's New
- Switching to EtherscanProvider instead of AlchemyProvider since they started limiting us
- Added Etherscan API key env var (already added it to heroku instance)