### PR TITLE
Handle discord posting errors

### DIFF
--- a/src/Utils/activityTriager.ts
+++ b/src/Utils/activityTriager.ts
@@ -101,9 +101,16 @@ function sendEmbedToChannel(
   channelId: string
 ) {
   const channel = bot.channels?.cache?.get(channelId) as TextChannel
-  channel.send({
-    embeds: [embed],
-  })
+  channel
+    .send({
+      embeds: [embed],
+    })
+    .catch((err) => {
+      console.log(
+        `Error posting message in channel ${projectConfig.channels[channelId].name} (id: ${channelId})`,
+        err.message
+      )
+    })
 }
 
 /**


### PR DESCRIPTION
Artbot keeps crashing when servers revoke its posting privileges / remove it from the server (recently happened with squiggleDAO discord)

This PR catches and legibly prints those errors