### PR TITLE
Only login to discord if not in test mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,9 @@ const bot = new Client({
     GatewayIntentBits.MessageContent,
   ],
 })
-bot.login(DISCORD_TOKEN)
+if (!TEST_MODE) {
+  bot.login(DISCORD_TOKEN)
+}
 
 bot.on('ready', () => {
   console.info(`Logged in as ${bot.user?.tag}!`)


### PR DESCRIPTION
Only login to discord if not in `TEST_MODE` - this should hopefully fix the CI issues non-AB contributors have been having!