### PR TITLE
Seperating Engine sales/lists in dynamic fashion

### DIFF
--- a/src/Utils/smartBotResponse.ts
+++ b/src/Utils/smartBotResponse.ts
@@ -1,6 +1,6 @@
+import { EmbedBuilder, ColorResolvable } from 'discord.js'
 import * as dotenv from 'dotenv'
 dotenv.config()
-const { EmbedBuilder } = require('discord.js')
 const fetch = require('node-fetch')
 const projectConfig = require('../ProjectConfig/projectConfig').projectConfig
 
@@ -21,8 +21,8 @@ const ARTBOT_GREEN = 0x00ff00
 const ARTBOT_WARNING = 0xffff00
 
 // Returns a random color
-function randomColor(): string {
-  return Math.floor(Math.random() * 16777215).toString(16)
+function randomColor(): ColorResolvable {
+  return `#${Math.floor(Math.random() * 16777215).toString(16)}`
 }
 
 // Thank you message for people asking the artbot how it is.
@@ -266,7 +266,7 @@ export async function smartBotResponse(
   msgAuthor: string,
   artBotID: string,
   channelID: string
-) {
+): Promise<string | EmbedBuilder | null> {
   /*
    * NOTE: It is important to check if the message author is the ArtBot
    *       Itself to avoid a recursive infinite loop.

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,32 +236,20 @@ const initReservoirBots = async () => {
     )
   }
 
-  const mainListParams = buildContractsString(
-    Object.values(CORE_CONTRACTS)
-      .concat(Object.values(COLLAB_CONTRACTS))
-      .concat(Object.values(EXPLORATIONS_CONTRACTS))
-  )
-  const mainSaleParams = mainListParams.replaceAll('contracts', 'contract')
-
-  createReservoirBots(mainListParams, mainSaleParams, API_POLL_TIME_MS)
-
-  // Handle Engine Contracts seperately and dynamically
-
-  const engineContracts = (await ENGINE_CONTRACTS).concat(
-    Object.values(CORE_CONTRACTS)
-      .concat(Object.values(COLLAB_CONTRACTS))
-      .concat(Object.values(EXPLORATIONS_CONTRACTS))
-  )
+  const allContracts = Object.values(CORE_CONTRACTS)
+    .concat(Object.values(COLLAB_CONTRACTS))
+    .concat(Object.values(EXPLORATIONS_CONTRACTS))
+    .concat(await ENGINE_CONTRACTS)
 
   const RESERVOIR_CONTRACT_LIMIT = 20
   const numBotInstances = Math.ceil(
-    engineContracts.length / RESERVOIR_CONTRACT_LIMIT
+    allContracts.length / RESERVOIR_CONTRACT_LIMIT
   )
   for (let i = 0; i < numBotInstances; i++) {
     const start = i * RESERVOIR_CONTRACT_LIMIT
     const end = start + RESERVOIR_CONTRACT_LIMIT
     const engineListParams = buildContractsString(
-      engineContracts.slice(start, end)
+      allContracts.slice(start, end)
     )
     const engineSaleParams = engineListParams.replaceAll(
       'contracts',
@@ -270,7 +258,7 @@ const initReservoirBots = async () => {
     createReservoirBots(
       engineListParams,
       engineSaleParams,
-      API_POLL_TIME_MS * (2.5 + i * 0.2)
+      API_POLL_TIME_MS + i * 3000
     )
   }
 }


### PR DESCRIPTION
- Reservoir has a limit of 20 contracts per query - which we now exceed with 19 Engine contracts + 5 Core/Collab/Explorations
- So, I added in this dynamic poll bot creation. Basically makes poll bots for every 20 contracts

Also made a small typing fix @mchrupcala commented on Izzy's PR!