### PR TITLE
Adding auto-indexing of new mints

### DIFF
--- a/src/Classes/ArtIndexerBot.ts
+++ b/src/Classes/ArtIndexerBot.ts
@@ -90,9 +90,11 @@ class ArtIndexerBot {
           heritageStatuses[`${project.contract.id}-${project.projectId}`]
         )
         const newBot = new ProjectBot(
+          project.id,
           project.projectId,
           project.contract.id,
           project.invocations,
+          project.maxInvocations,
           project.name,
           project.active,
           undefined,

--- a/src/Classes/ProjectBot.ts
+++ b/src/Classes/ProjectBot.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios'
 import { Message } from 'discord.js'
-import { projectRefreshInvocations } from '../Utils/parseArtBlocksAPI'
+import { getProjectInvocations } from '../Utils/parseArtBlocksAPI'
 
 const { EmbedBuilder } = require('discord.js')
 const axios = require('axios')
@@ -114,9 +114,7 @@ export class ProjectBot {
 
     // If project is still minting, refresh edition size to see if piece is in bounds
     if (pieceNumber >= this.editionSize && pieceNumber < this.maxEditionSize) {
-      const invocations: number | null = await projectRefreshInvocations(
-        this.id
-      )
+      const invocations: number | null = await getProjectInvocations(this.id)
 
       if (invocations) {
         this.editionSize = invocations

--- a/src/Classes/ProjectBot.ts
+++ b/src/Classes/ProjectBot.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios'
 import { Message } from 'discord.js'
+import { projectRefreshInvocations } from '../Utils/parseArtBlocksAPI'
 
 const { EmbedBuilder } = require('discord.js')
 const axios = require('axios')
@@ -18,9 +19,11 @@ const ONE_MILLION = 1e6
  * Bot for handling projects
  */
 export class ProjectBot {
+  id: string
   projectNumber: number
   coreContract: string
   editionSize: number
+  maxEditionSize: number
   projectName: string
   projectActive: boolean
   namedMappings: any
@@ -30,9 +33,11 @@ export class ProjectBot {
   startTime?: Date
 
   constructor(
+    id: string,
     projectNumber: number,
     coreContract: string,
     editionSize: number,
+    maxEditionSize: number,
     projectName: string,
     projectActive: boolean,
     namedMappings: any,
@@ -41,9 +46,11 @@ export class ProjectBot {
     heritageStatus?: string,
     startTime?: Date
   ) {
+    this.id = id
     this.projectNumber = projectNumber
     this.coreContract = coreContract
     this.editionSize = editionSize
+    this.maxEditionSize = maxEditionSize
     this.projectName = projectName
     this.projectActive = projectActive
     this.namedMappings = namedMappings
@@ -103,6 +110,17 @@ export class ProjectBot {
       pieceNumber = Math.floor(Math.random() * this.editionSize)
     } else {
       pieceNumber = parseInt(afterTheHash)
+    }
+
+    // If project is still minting, refresh edition size to see if piece is in bounds
+    if (pieceNumber >= this.editionSize && pieceNumber < this.maxEditionSize) {
+      const invocations: number | null = await projectRefreshInvocations(
+        this.id
+      )
+
+      if (invocations) {
+        this.editionSize = invocations
+      }
     }
 
     if (pieceNumber >= this.editionSize || pieceNumber < 0) {

--- a/src/ProjectConfig/projectConfig.ts
+++ b/src/ProjectConfig/projectConfig.ts
@@ -202,17 +202,17 @@ class ProjectConfig {
         )
       }
       const projectNumber = parseInt(projectId)
-      const { invocations, name, active, contract } = await getContractProject(
-        projectNumber,
-        configContract
-      )
+      const { id, invocations, maxInvocations, name, active, contract } =
+        await getContractProject(projectNumber, configContract)
       console.log(
         `Refreshing project cache for Project ${projectNumber} ${name}`
       )
       projectBots[botId] = new ProjectBot(
+        id,
         projectNumber,
         contract.id,
         invocations,
+        maxInvocations,
         name,
         active,
         namedMappings

--- a/src/Utils/parseArtBlocksAPI.js
+++ b/src/Utils/parseArtBlocksAPI.js
@@ -50,6 +50,14 @@ const getAllProjectsCurationStatus = gql`
   }
 `
 
+const projectInvocations = gql`
+  query getProjectInvocations($id: ID!) {
+    projects(where: { id: $id }) {
+      invocations
+    }
+  }
+`
+
 const contractProjectsMinimal = gql`
   query getContractProjectsMinimal($id: ID!, $first: Int!, $skip: Int) {
     contract(id: $id) {
@@ -64,6 +72,7 @@ const contractProjects = gql`
   query getContractProjects($id: ID!, $first: Int!, $skip: Int) {
     contract(id: $id) {
       projects(first: $first, skip: $skip, orderBy: projectId) {
+        id
         projectId
         name
         invocations
@@ -106,6 +115,7 @@ const contractProject = gql`
   query getContractProject($id: ID!, $projectId: Int!) {
     contract(id: $id) {
       projects(where: { projectId: $projectId }) {
+        id
         name
         invocations
         maxInvocations
@@ -237,6 +247,22 @@ async function _getContractProject(projectId, contractId) {
       .toPromise()
     return result.data.contract.projects.length > 0
       ? result.data.contract.projects[0]
+      : null
+  } catch (err) {
+    console.error(err)
+    return undefined
+  }
+}
+
+export async function projectRefreshInvocations(id) {
+  try {
+    const result = await client
+      .query(projectInvocations, {
+        id: id,
+      })
+      .toPromise()
+    return result.data.projects.length > 0
+      ? result.data.projects[0].invocations
       : null
   } catch (err) {
     console.error(err)

--- a/src/Utils/parseArtBlocksAPI.js
+++ b/src/Utils/parseArtBlocksAPI.js
@@ -254,7 +254,7 @@ async function _getContractProject(projectId, contractId) {
   }
 }
 
-export async function projectRefreshInvocations(id) {
+export async function getProjectInvocations(id) {
   try {
     const result = await client
       .query(projectInvocations, {


### PR DESCRIPTION
When someone does `#x <projectName>` for a project that is still minting (i.e. invocations < maxInvocations), and `invocations < x < maxInvocations`, Artbot will now ping the subgraph to see if that new token has been minted. This will save us lots of manual restarting during / after mints!