### PR TITLE
remove urql caching

### DIFF
--- a/src/Utils/parseArtBlocksAPI.js
+++ b/src/Utils/parseArtBlocksAPI.js
@@ -26,6 +26,7 @@ const client = createClient({
       'Content-Type': 'application/json',
     },
   }),
+  requestPolicy: 'network-only',
 })
 
 const projectsStartTimes = gql`


### PR DESCRIPTION
Changing the policy on the urql client to never use caching
- Encountered a bug during today's drop where the new auto-indexing feature (https://github.com/ArtBlocks/artbot/pull/472) worked the first time we tried it (when the first 7 tokens were minted), but from that point onwards insisted there were only 7 tokens minted. I believe this is because the subgraph request introduced in that PR was being cached from the first time it was queried
- Essentially all other subgraph requests in artbot happen just once on startup, so the lack of caching shouldn't effect them at all!