### PR TITLE
Fixing artbot rate limit

### DIFF
--- a/src/Data/queryGraphQL.ts
+++ b/src/Data/queryGraphQL.ts
@@ -33,6 +33,14 @@ const BLOCKED_ENGINE_CONTRACTS: {
 const client = createClient({
   url: PUBLIC_HASURA_ENDPOINT,
   fetch: fetch,
+  fetchOptions: process.env.HASURA_GRAPHQL_ADMIN_SECRET
+    ? () => ({
+        headers: {
+          'x-hasura-admin-secret':
+            process.env.HASURA_GRAPHQL_ADMIN_SECRET ?? '',
+        },
+      })
+    : undefined,
   requestPolicy: 'network-only',
 })
 


### PR DESCRIPTION
Artbot is getting rate limited! adding option to use hasura secret if the env var is set so that production artbot can circumvent