### PR TITLE
changing fallback token url

### DIFF
--- a/src/Classes/APIBots/ReservoirListBot.ts
+++ b/src/Classes/APIBots/ReservoirListBot.ts
@@ -11,6 +11,7 @@ import {
   ensOrAddress,
   getCollectionType,
   getTokenApiUrl,
+  getTokenUrl,
   isEngineContract,
   isExplorationsContract,
   replaceVideoWithGIF,
@@ -136,9 +137,14 @@ export class ReservoirListBot extends APIPollBot {
     )
 
     // Get Art Blocks metadata response for the item.
-    const tokenUrl = getTokenApiUrl(listing.contract, tokenID)
-    const artBlocksResponse = await axios.get(tokenUrl)
+    const tokenApiUrl = getTokenApiUrl(listing.contract, tokenID)
+    const artBlocksResponse = await axios.get(tokenApiUrl)
     const artBlocksData = artBlocksResponse?.data
+    const tokenUrl = getTokenUrl(
+      artBlocksData.external_url,
+      listing.contract,
+      tokenID
+    )
 
     let curationStatus = artBlocksData?.curation_status
       ? artBlocksData.curation_status[0].toUpperCase() +
@@ -173,10 +179,7 @@ export class ReservoirListBot extends APIPollBot {
       },
       {
         name: 'Live Script',
-        value: `[view on artblocks.io](${
-          (artBlocksData.external_url || artBlocksData.generator_url) +
-          LISTING_UTM
-        })`,
+        value: `[view on artblocks.io](${tokenUrl + LISTING_UTM})`,
         inline: true,
       }
     )

--- a/src/Classes/APIBots/ReservoirSaleBot.ts
+++ b/src/Classes/APIBots/ReservoirSaleBot.ts
@@ -14,6 +14,7 @@ import {
   SALE_UTM,
   ensOrAddress,
   replaceVideoWithGIF,
+  getTokenUrl,
 } from './utils'
 
 type ReservoirSale = {
@@ -164,9 +165,15 @@ export class ReservoirSaleBot extends APIPollBot {
     }
 
     // Get Art Blocks metadata response for the item.
-    const tokenUrl = getTokenApiUrl(sale.token.contract, tokenID)
-    const artBlocksResponse = await axios.get(tokenUrl)
+    const tokenApiUrl = getTokenApiUrl(sale.token.contract, tokenID)
+    const artBlocksResponse = await axios.get(tokenApiUrl)
     const artBlocksData = artBlocksResponse?.data
+
+    const tokenUrl = getTokenUrl(
+      artBlocksData.external_url,
+      sale.token.contract,
+      tokenID
+    )
 
     let sellerText = await ensOrAddress(sale.from)
     let buyerText = await ensOrAddress(sale.to)
@@ -174,7 +181,7 @@ export class ReservoirSaleBot extends APIPollBot {
       platform,
       sale.token.contract,
       sale.token.tokenId,
-      artBlocksData.external_url
+      tokenUrl
     )
 
     if (platform.includes('opensea')) {
@@ -239,9 +246,7 @@ export class ReservoirSaleBot extends APIPollBot {
       },
       {
         name: 'Live Script',
-        value: `[view on artblocks.io](${
-          (artBlocksData.external_url || artBlocksData.generator_url) + SALE_UTM
-        })`,
+        value: `[view on artblocks.io](${tokenUrl + SALE_UTM})`,
         inline: true,
       }
     )

--- a/src/Classes/APIBots/utils.ts
+++ b/src/Classes/APIBots/utils.ts
@@ -222,6 +222,21 @@ export async function getCollectionType(
   throw new Error('Unknown collection type')
 }
 
+export function getTokenUrl(
+  external_url: string,
+  contractAddr: string,
+  tokenId: string
+): string {
+  if (external_url && !external_url.includes('generator.artblocks.io')) {
+    return external_url
+  }
+  return buildArtBlocksTokenURL(contractAddr, tokenId)
+}
+
+function buildArtBlocksTokenURL(contractAddr: string, tokenId: string): string {
+  return `https://www.artblocks.io/token/${contractAddr}-${tokenId}`
+}
+
 export function buildOpenseaURL(contractAddr: string, tokenId: string): string {
   return `https://opensea.io/assets/ethereum/${contractAddr}/${tokenId}`
 }

--- a/src/Classes/MintBot.ts
+++ b/src/Classes/MintBot.ts
@@ -1,7 +1,12 @@
 import { Client, EmbedBuilder, TextChannel } from 'discord.js'
 import { ENGINE_CONTRACTS, mintBot } from '../index'
 import axios, { AxiosError } from 'axios'
-import { MINT_UTM, getTokenApiUrl, replaceVideoWithGIF } from './APIBots/utils'
+import {
+  MINT_UTM,
+  getTokenApiUrl,
+  getTokenUrl,
+  replaceVideoWithGIF,
+} from './APIBots/utils'
 import { ensOrAddress } from './APIBots/utils'
 import { TwitterBot } from './TwitterBot'
 
@@ -119,7 +124,11 @@ export class MintBot {
               mint.generatorLink = artBlocksData.generator_url
               mint.tokenName = artBlocksData.name
               mint.artistName = artBlocksData.artist
-              mint.artblocksUrl = artBlocksData.external_url
+              mint.artblocksUrl = getTokenUrl(
+                artBlocksData.external_url,
+                mint.contractAddress,
+                mint.tokenId
+              )
               mint.postToDiscord()
               this.twitterBot?.sendToTwitter(mint)
             }

--- a/src/Classes/ProjectBot.ts
+++ b/src/Classes/ProjectBot.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios'
 import { Message } from 'discord.js'
-import { PROJECTBOT_UTM } from './APIBots/utils'
+import { PROJECTBOT_UTM, getTokenUrl } from './APIBots/utils'
 
 import { ensOrAddress, replaceVideoWithGIF } from './APIBots/utils'
 import {
@@ -169,7 +169,7 @@ export class ProjectBot {
     const artBlocksData = artBlocksResponse.data
 
     const titleLink =
-      (artBlocksData.external_url || artBlocksData.generator_url) +
+      getTokenUrl(artBlocksData.external_url, this.coreContract, tokenID) +
       PROJECTBOT_UTM
 
     let title = artBlocksData.name + ' - ' + artBlocksData.artist


### PR DESCRIPTION
Replacing engine token url to fallback to our `artblocks.io/token/<token-id>` endpoint that I didn't know we had

Also adding a custom workaround for BM since they set their external_url to be our generator for some reason