### PR TITLE
Add spin alias

### DIFF
--- a/src/ProjectConfig/project_aliases.json
+++ b/src/ProjectConfig/project_aliases.json
@@ -53,5 +53,6 @@
   "hu": "Human Unreadable",
   "auto": "Automatism",
   "autos": "Automatism",
-  "pm": "Polychrome Music"
+  "pm": "Polychrome Music",
+  "spin": "SPINᵗ"
 }


### PR DESCRIPTION
SPINᵗ has a special superscript character which makes it hard to easily call up in #block-talk. Adding an alias for "Spin" so it's easier for people to enjoy Matt's great art.