### PR TITLE
ban wallets repeatedly listing skulptuurs with bot

### DIFF
--- a/src/Utils/activityTriager.ts
+++ b/src/Utils/activityTriager.ts
@@ -103,6 +103,8 @@ export const BAN_ADDRESSES = new Set([
   '0x664e3a3a6a6fa524d06f4d612fe8440b923574bd',
   '0x43fcf64fd6dde18272b62a5b365dd8e70bdde38d',
   '0x8f4b93b496de681f9f9a629704da1ff90da8c93c',
+  '0xa60e9090ac0553a199671a4b9067b7814385228f',
+  '0xada6cbd477311409df392f869c21f384a2d9d1ff',
 ])
 
 function sendEmbedToChannel(


### PR DESCRIPTION
This PR adds the two wallets who are repeatedly listing skulptuurs with a bot causing #listing-feed to become spammed 
<img width="510" alt="Screenshot 2024-01-02 at 1 00 54 PM" src="https://github.com/ArtBlocks/artbot/assets/154624415/4c53e113-3902-4496-9c3e-11ca53f6e4f4">
