### PR TITLE
using opensea api for lists/sales

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@graphql-codegen/typescript-urql": "^3.7.3",
     "@graphql-codegen/urql-introspection": "^2.2.1",
     "@graphql-tools/utils": "^8.3.0",
+    "@opensea/stream-js": "^0.2.1",
     "@reservoir0x/reservoir-sdk": "^2.4.32",
     "@supabase/supabase-js": "^2.29.0",
     "@types/node": "20.1.2",
@@ -64,6 +65,7 @@
     "ms": "^2.0.0",
     "node-fetch": "^2.6.1",
     "node-html-parser": "^3.2.0",
+    "node-localstorage": "^3.0.5",
     "openai": "^4.73.0",
     "prettier": "^2.6.2",
     "react": "18.2.0",
@@ -76,6 +78,10 @@
     "urql": "^3.0.3",
     "viem": "2.17.4",
     "web3": "^1.7.0",
-    "ws": "^8.17.1"
+    "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "@types/node-localstorage": "^1.3.3",
+    "@types/phoenix": "^1.6.6"
   }
 }

--- a/src/Classes/APIBots/OpenSeaListBot.ts
+++ b/src/Classes/APIBots/OpenSeaListBot.ts
@@ -1,0 +1,227 @@
+import axios from 'axios'
+import { Client, ColorResolvable, EmbedBuilder } from 'discord.js'
+import {
+  BAN_ADDRESSES,
+  sendEmbedToListChannels,
+} from '../../Utils/activityTriager'
+import {
+  LISTING_UTM,
+  ensOrAddress,
+  getCollectionType,
+  getTokenApiUrl,
+  getTokenUrl,
+  replaceVideoWithGIF,
+  isEngineContract,
+  isExplorationsContract,
+} from './utils'
+import { ItemListedEvent } from '@opensea/stream-js'
+
+const IDENTICAL_TOLERANCE = 0.0001
+const LISTING_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+/**
+ * Bot for handling OpenSea stream listing events
+ * Similar to ReservoirListBot but for OpenSea stream data
+ */
+export class OpenSeaListBot {
+  private bot: Client
+  private recentListings: {
+    [key: string]: { price: number; timestamp: number }
+  } = {}
+  private listColor = '#407FDB'
+
+  constructor(bot: Client) {
+    this.bot = bot
+
+    // Setup cleanup interval for old listings
+    setInterval(() => {
+      this.cleanupOldListings()
+    }, 60 * 60 * 1000) // Clean up every hour
+  }
+
+  /**
+   * Cleanup listings older than TTL
+   */
+  private cleanupOldListings() {
+    const now = Date.now()
+    Object.entries(this.recentListings).forEach(([key, value]) => {
+      if (now - value.timestamp > LISTING_TTL_MS) {
+        delete this.recentListings[key]
+      }
+    })
+  }
+
+  /**
+   * Main handler for OpenSea listing events
+   * @param event - OpenSea stream event data
+   */
+  async handleListingEvent(event: ItemListedEvent) {
+    try {
+      await this.buildDiscordMessage(event.payload)
+    } catch (err) {
+      console.error('Error processing OpenSea listing event:', err)
+    }
+  }
+
+  /**
+   * Parses OpenSea NFT ID and extracts contract address and token ID
+   * @param nftId - Format: "ethereum/0x2308742aa28cc460522ff855d24a365f99deba7b/7111"
+   * @returns {contractAddress, tokenId} or null if invalid format
+   */
+  private parseNftId(
+    nftId: string
+  ): { contractAddress: string; tokenId: string } | null {
+    const parts = nftId.split('/')
+    if (parts.length !== 3) {
+      console.warn('Invalid NFT ID format:', nftId)
+      return null
+    }
+
+    return {
+      contractAddress: parts[1].toLowerCase(),
+      tokenId: parts[2],
+    }
+  }
+
+  /**
+   * Builds and sends Discord embed message for OpenSea listing
+   * @param payload - OpenSea stream payload
+   */
+  async buildDiscordMessage(payload: ItemListedEvent['payload']) {
+    const embed = new EmbedBuilder()
+
+    // Parse the NFT ID to get contract and token info
+    const nftInfo = this.parseNftId(payload.item.nft_id)
+    if (!nftInfo) {
+      console.warn('Could not parse NFT ID:', payload.item.nft_id)
+      return
+    }
+
+    const { contractAddress, tokenId } = nftInfo
+    const priceText = 'List Price'
+    const price = parseFloat(
+      parseFloat(payload.payment_token.eth_price).toFixed(4)
+    )
+    const currency = payload.payment_token.symbol
+    const owner = payload.maker.address
+    const platform = 'OpenSea'
+
+    // Check for duplicate listings (same token, similar price)
+    if (
+      this.recentListings[tokenId] &&
+      Math.abs(this.recentListings[tokenId].price - price) <=
+        IDENTICAL_TOLERANCE
+    ) {
+      console.log(`Skipping identical OpenSea relisting for ${tokenId}`)
+      return
+    }
+    this.recentListings[tokenId] = { price, timestamp: Date.now() }
+
+    // Apply colors and platform styling
+    embed.setColor(this.listColor as ColorResolvable) // Default to general listing color
+
+    // Skip banned addresses
+    if (BAN_ADDRESSES.has(owner)) {
+      console.log(`Skipping OpenSea listing from banned address: ${owner}`)
+      return
+    }
+
+    try {
+      // Get Art Blocks metadata response for the item (same as ReservoirListBot)
+      const tokenApiUrl = getTokenApiUrl(contractAddress, tokenId)
+      const artBlocksResponse = await axios.get(tokenApiUrl)
+      const artBlocksData = artBlocksResponse?.data
+      const tokenUrl = getTokenUrl(
+        artBlocksData.external_url,
+        contractAddress,
+        tokenId
+      )
+
+      const sellerText = await ensOrAddress(owner)
+      const baseABProfile = 'https://www.artblocks.io/user/'
+      const sellerProfile = baseABProfile + owner + LISTING_UTM
+
+      embed.addFields(
+        {
+          name: `Seller (${platform})`,
+          value: `[${sellerText}](${sellerProfile})`,
+        },
+        {
+          name: priceText,
+          value: `${price} ${currency}`,
+          inline: true,
+        }
+      )
+
+      let curationStatus = artBlocksData?.curation_status
+        ? artBlocksData.curation_status[0].toUpperCase() +
+          artBlocksData.curation_status.slice(1).toLowerCase()
+        : ''
+
+      let title = `${artBlocksData.name} - ${artBlocksData.artist}`
+
+      if (artBlocksData?.platform?.includes('Art Blocks x Pace')) {
+        curationStatus = 'AB x Pace'
+      } else if (artBlocksData?.platform === 'Art Blocks × Bright Moments') {
+        curationStatus = 'AB x Bright Moments'
+      } else if (isExplorationsContract(contractAddress)) {
+        curationStatus = 'Explorations'
+      } else if (isEngineContract(contractAddress)) {
+        curationStatus = 'Engine'
+        if (artBlocksData?.platform) {
+          title = `${artBlocksData.platform} - ${title}`
+        }
+      }
+
+      // Update thumbnail image to use larger variant from Art Blocks API.
+      let assetUrl = artBlocksData?.preview_asset_url
+      if (assetUrl && !assetUrl.includes('undefined')) {
+        assetUrl = await replaceVideoWithGIF(assetUrl)
+        embed.setThumbnail(assetUrl)
+      }
+
+      // Add fields
+      const fields = []
+      if (curationStatus && curationStatus.trim()) {
+        fields.push({
+          name: 'Collection',
+          value: curationStatus,
+          inline: true,
+        })
+      }
+
+      fields.push({
+        name: 'Live Script',
+        value: `[view on artblocks.io](${tokenUrl + LISTING_UTM})`,
+        inline: true,
+      })
+
+      embed.addFields(...fields)
+
+      const platformUrl = payload.item.permalink
+
+      embed.setTitle(title)
+      if (platformUrl) {
+        embed.setURL(platformUrl + LISTING_UTM)
+      }
+      if (artBlocksData.collection_name) {
+        console.log(artBlocksData.name + ' OpenSea LIST')
+        sendEmbedToListChannels(
+          this.bot,
+          embed,
+          artBlocksData,
+          await getCollectionType(contractAddress)
+        )
+      }
+    } catch (error) {
+      console.error('Error building OpenSea listing message:', error)
+    }
+  }
+
+  /**
+   * Cleanup method to be called when the bot is being destroyed
+   */
+  cleanup() {
+    this.recentListings = {}
+  }
+}

--- a/src/Classes/APIBots/OpenSeaListBot.ts
+++ b/src/Classes/APIBots/OpenSeaListBot.ts
@@ -77,6 +77,11 @@ export class OpenSeaListBot {
       return null
     }
 
+    if (parts[0] !== 'ethereum') {
+      console.warn('Invalid NFT ID format:', nftId)
+      return null
+    }
+
     return {
       contractAddress: parts[1].toLowerCase(),
       tokenId: parts[2],

--- a/src/Classes/APIBots/OpenSeaSaleBot.ts
+++ b/src/Classes/APIBots/OpenSeaSaleBot.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { Client, EmbedBuilder } from 'discord.js'
+import { formatEther } from 'viem'
 import {
   BAN_ADDRESSES,
   sendEmbedToSaleChannels,
@@ -130,9 +131,11 @@ export class OpenSeaSaleBot {
 
     const { contractAddress, tokenId } = nftInfo
     const priceText = 'Sale Price'
-    const price = parseFloat(
-      parseFloat(payload.payment_token.eth_price).toFixed(4)
-    )
+
+    // Convert sale_price from wei to ETH using viem
+    const priceInEth = formatEther(BigInt(payload.sale_price))
+    const price = parseFloat(parseFloat(priceInEth).toFixed(4))
+
     const usdPrice = parseFloat(
       parseFloat(payload.payment_token.usd_price).toFixed(2)
     )
@@ -318,7 +321,10 @@ export class OpenSeaSaleBot {
       return false
     }
 
-    const price = parseFloat(payload.payment_token.eth_price)
+    // Convert sale_price from wei to ETH for price threshold check
+    const priceInEth = formatEther(BigInt(payload.sale_price))
+    const price = parseFloat(priceInEth)
+
     if (price < 0.1 && payload.payment_token.symbol.includes('ETH')) {
       console.log(
         'Skipping twitter sale for low-value OpenSea sale',

--- a/src/Classes/APIBots/OpenSeaSaleBot.ts
+++ b/src/Classes/APIBots/OpenSeaSaleBot.ts
@@ -1,0 +1,335 @@
+import axios from 'axios'
+import { Client, EmbedBuilder } from 'discord.js'
+import {
+  BAN_ADDRESSES,
+  sendEmbedToSaleChannels,
+} from '../../Utils/activityTriager'
+import {
+  getTokenApiUrl,
+  isExplorationsContract,
+  isEngineContract,
+  getCollectionType,
+  SALE_UTM,
+  ensOrAddress,
+  replaceVideoWithGIF,
+  getTokenUrl,
+  isStudioContract,
+  getOSName,
+} from './utils'
+import { ItemSoldEvent } from '@opensea/stream-js'
+import { TwitterBot } from '../TwitterBot'
+import { artIndexerBot } from '../..'
+
+const IDENTICAL_TOLERANCE = 0.0001
+const SALE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+/**
+ * Bot for handling OpenSea stream sale events
+ * Similar to ReservoirSaleBot but for OpenSea stream data
+ */
+export class OpenSeaSaleBot {
+  private bot: Client
+  private twitterBot?: TwitterBot
+  private recentSales: { [key: string]: { price: number; timestamp: number } } =
+    {}
+  private saleColor = 0x27ae60 // Green color for OpenSea sales (different from Reservoir)
+
+  constructor(bot: Client, twitterBot?: TwitterBot) {
+    this.bot = bot
+    this.twitterBot = twitterBot
+
+    // Setup cleanup interval for old sales
+    setInterval(() => {
+      this.cleanupOldSales()
+    }, 60 * 60 * 1000) // Clean up every hour
+  }
+
+  /**
+   * Cleanup sales older than TTL
+   */
+  private cleanupOldSales() {
+    const now = Date.now()
+    Object.entries(this.recentSales).forEach(([key, value]) => {
+      if (now - value.timestamp > SALE_TTL_MS) {
+        delete this.recentSales[key]
+      }
+    })
+  }
+
+  /**
+   * Main handler for OpenSea sale events
+   * @param event - OpenSea stream event data
+   */
+  async handleSaleEvent(event: ItemSoldEvent) {
+    try {
+      await this.buildDiscordMessage(event.payload)
+    } catch (err) {
+      console.error('Error processing OpenSea sale event:', err)
+    }
+  }
+
+  /**
+   * Parses OpenSea NFT ID and extracts contract address and token ID
+   * @param nftId - Format: "ethereum/0x2308742aa28cc460522ff855d24a365f99deba7b/7111"
+   * @returns {contractAddress, tokenId} or null if invalid format
+   */
+  private parseNftId(
+    nftId: string
+  ): { contractAddress: string; tokenId: string } | null {
+    const parts = nftId.split('/')
+    if (parts.length !== 3) {
+      console.warn('Invalid NFT ID format:', nftId)
+      return null
+    }
+
+    return {
+      contractAddress: parts[1].toLowerCase(),
+      tokenId: parts[2],
+    }
+  }
+
+  /**
+   * Get OpenSea name for an address (similar to ReservoirSaleBot)
+   */
+  private async osName(address: string): Promise<string> {
+    return await getOSName(address)
+  }
+
+  /**
+   * Get platform URL for the sale (similar to ReservoirSaleBot.getPlatformUrl)
+   */
+  private getPlatformUrl(
+    platform: string,
+    contractAddress: string,
+    tokenId: string,
+    tokenUrl: string
+  ): string {
+    // For OpenSea, we can use the permalink from the payload
+    // This method is here for consistency with ReservoirSaleBot structure
+    return tokenUrl
+  }
+
+  /**
+   * Builds and sends Discord embed message for OpenSea sale
+   * @param payload - OpenSea stream payload
+   */
+  async buildDiscordMessage(payload: ItemSoldEvent['payload']) {
+    const embed = new EmbedBuilder()
+
+    // Parse the NFT ID to get contract and token info
+    const nftInfo = this.parseNftId(payload.item.nft_id)
+    if (!nftInfo) {
+      console.warn('Could not parse NFT ID:', payload.item.nft_id)
+      return
+    }
+
+    const { contractAddress, tokenId } = nftInfo
+    const priceText = 'Sale Price'
+    const price = parseFloat(
+      parseFloat(payload.payment_token.eth_price).toFixed(4)
+    )
+    const usdPrice = parseFloat(
+      parseFloat(payload.payment_token.usd_price).toFixed(2)
+    )
+    const currency = payload.payment_token.symbol
+    const seller = payload.maker.address
+    const buyer = payload.taker.address
+    let platform = 'OpenSea'
+
+    // Check for duplicate sales (same token, similar price)
+    if (
+      this.recentSales[tokenId] &&
+      Math.abs(this.recentSales[tokenId].price - price) <= IDENTICAL_TOLERANCE
+    ) {
+      console.log(`Skipping identical OpenSea resale for ${tokenId}`)
+      return
+    }
+    this.recentSales[tokenId] = { price, timestamp: Date.now() }
+
+    embed.setColor(this.saleColor)
+    platform = 'OpenSea'
+
+    // Skip banned addresses
+    if (BAN_ADDRESSES.has(seller)) {
+      console.log(`Skipping OpenSea sale from banned address: ${seller}`)
+      return
+    }
+
+    try {
+      // Get Art Blocks metadata response for the item (same as ReservoirSaleBot)
+      const tokenApiUrl = getTokenApiUrl(contractAddress, tokenId)
+      const artBlocksResponse = await axios.get(tokenApiUrl)
+      const artBlocksData = artBlocksResponse?.data
+
+      const tokenUrl = getTokenUrl(
+        artBlocksData.external_url,
+        contractAddress,
+        tokenId
+      )
+
+      let sellerText = await ensOrAddress(seller)
+      let buyerText = await ensOrAddress(buyer)
+      const platformUrl = this.getPlatformUrl(
+        platform,
+        contractAddress,
+        tokenId,
+        tokenUrl
+      )
+
+      // Add OpenSea usernames if available (same logic as ReservoirSaleBot)
+      if (!sellerText.includes('.eth')) {
+        const sellerOS = await this.osName(seller)
+        sellerText =
+          sellerOS === '' ? sellerText : `${sellerText} (OS: ${sellerOS})`
+      }
+      if (!buyerText.includes('.eth')) {
+        const buyerOS = await this.osName(buyer)
+        buyerText = buyerOS === '' ? buyerText : `${buyerText} (OS: ${buyerOS})`
+      }
+
+      const baseABProfile = 'https://www.artblocks.io/user/'
+      const sellerProfile = baseABProfile + seller + SALE_UTM
+      const buyerProfile = baseABProfile + buyer + SALE_UTM
+
+      embed.addFields(
+        {
+          name: `Seller (${platform})`,
+          value: `[${sellerText}](${sellerProfile})`,
+        },
+        {
+          name: `Buyer`,
+          value: `[${buyerText}](${buyerProfile})`,
+        },
+        {
+          name: priceText,
+          value: `${price} ${currency}`,
+          inline: true,
+        }
+      )
+
+      let title = `${artBlocksData.name} - ${artBlocksData.artist}`
+
+      let curationStatus = artBlocksData?.curation_status
+        ? artBlocksData.curation_status[0].toUpperCase() +
+          artBlocksData.curation_status.slice(1).toLowerCase()
+        : ''
+
+      if (artBlocksData?.platform?.includes('Art Blocks x Pace')) {
+        curationStatus = 'AB x Pace'
+      } else if (artBlocksData?.platform === 'Art Blocks × Bright Moments') {
+        curationStatus = 'AB x Bright Moments'
+      } else if (isExplorationsContract(contractAddress)) {
+        curationStatus = 'Explorations'
+      } else if (isStudioContract(contractAddress)) {
+        curationStatus = 'Studio'
+      } else if (isEngineContract(contractAddress)) {
+        curationStatus = 'Engine'
+        if (artBlocksData?.platform) {
+          title = `${artBlocksData.platform} - ${title}`
+        }
+      }
+
+      // Update thumbnail image to use larger variant from Art Blocks API.
+      let assetUrl = artBlocksData?.preview_asset_url
+      if (assetUrl && !assetUrl.includes('undefined')) {
+        assetUrl = await replaceVideoWithGIF(assetUrl)
+        embed.setThumbnail(assetUrl)
+      }
+
+      // Only add Collection field if curationStatus has a value
+      const fields = []
+      if (curationStatus && curationStatus.trim()) {
+        fields.push({
+          name: `Collection`,
+          value: `${curationStatus}`,
+          inline: true,
+        })
+      }
+      fields.push({
+        name: 'Live Script',
+        value: `[view on artblocks.io](${tokenUrl + SALE_UTM})`,
+        inline: true,
+      })
+
+      embed.addFields(...fields)
+      embed.setTitle(title)
+      if (platformUrl) {
+        embed.setURL(platformUrl + SALE_UTM)
+      }
+
+      if (artBlocksData.collection_name) {
+        console.log(artBlocksData.name + ' OpenSea SALE')
+        sendEmbedToSaleChannels(
+          this.bot,
+          embed,
+          artBlocksData,
+          await getCollectionType(contractAddress)
+        )
+      }
+
+      // Post to Twitter if TwitterBot is available and sale meets criteria
+      if (this.twitterBot && this.shouldTweetSale(payload, artBlocksData)) {
+        try {
+          await this.twitterBot.tweetSale({
+            tokenName: artBlocksData.name,
+            projectName: artBlocksData.collection_name,
+            artist: artBlocksData.artist,
+            salePrice: price,
+            usdPrice: usdPrice,
+            currency: currency,
+            buyer: buyer,
+            seller: seller,
+            assetUrl: assetUrl || artBlocksData.preview_asset_url,
+            tokenUrl: tokenUrl,
+            platform: platform,
+          })
+        } catch (error) {
+          console.error('Error posting OpenSea sale to Twitter:', error)
+        }
+      }
+    } catch (error) {
+      console.error('Error building OpenSea sale message:', error)
+    }
+  }
+
+  /**
+   * Determines whether a sale should be posted to Twitter
+   * Similar logic to ReservoirSaleBot but adapted for OpenSea events
+   */
+  private shouldTweetSale(
+    payload: ItemSoldEvent['payload'],
+    artBlocksData: any
+  ): boolean {
+    const nftInfo = this.parseNftId(payload.item.nft_id)
+    if (!nftInfo) return false
+
+    const projectId = `${nftInfo.contractAddress.toLowerCase()}-${
+      artBlocksData.project_id
+    }`
+    const isAB500 = artIndexerBot.isAB500(projectId)
+
+    if (!isAB500) {
+      console.log('Skipping twitter sale for non-AB500 project', projectId)
+      return false
+    }
+
+    const price = parseFloat(payload.payment_token.eth_price)
+    if (price < 0.1 && payload.payment_token.symbol.includes('ETH')) {
+      console.log(
+        'Skipping twitter sale for low-value OpenSea sale',
+        price,
+        payload.payment_token.symbol
+      )
+      return false
+    }
+
+    return true
+  }
+
+  /**
+   * Cleanup method to be called when the bot is being destroyed
+   */
+  cleanup() {
+    this.recentSales = {}
+  }
+}

--- a/src/Classes/APIBots/OpenSeaSaleBot.ts
+++ b/src/Classes/APIBots/OpenSeaSaleBot.ts
@@ -82,6 +82,11 @@ export class OpenSeaSaleBot {
       return null
     }
 
+    if (parts[0] !== 'ethereum') {
+      console.warn('Invalid NFT ID format:', nftId)
+      return null
+    }
+
     return {
       contractAddress: parts[1].toLowerCase(),
       tokenId: parts[2],

--- a/src/Classes/APIBots/utils.ts
+++ b/src/Classes/APIBots/utils.ts
@@ -296,7 +296,6 @@ export const waitForStudioContracts = async (): Promise<string[]> => {
     console.log('Waiting for studio contracts to load...')
     await delay(4000)
   }
-  console.log('studio contracts loaded')
   return STUDIO_CONTRACTS
 }
 export const waitForEngineContracts = async (): Promise<string[]> => {
@@ -304,7 +303,6 @@ export const waitForEngineContracts = async (): Promise<string[]> => {
     console.log('Waiting for engine contracts to load...')
     await delay(5000)
   }
-  console.log('Engine contracts loaded')
   return ENGINE_CONTRACTS
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,6 +419,8 @@ const isTrackedContract = (
   const parts = nftId.split('/')
   if (parts.length !== 3) return false
 
+  if (parts[0] !== 'ethereum') return false
+
   const contractAddress = parts[1].toLowerCase()
 
   // Check if this contract address is in our tracked contracts
@@ -485,6 +487,8 @@ openseaStreamClient.onItemSold('*', async (event) => {
   }
 })
 
+// 8/28/2025 NOTE: We are migrating to OS API off of Reservoir
+// Keeping these around for now in case we need to revert, but these will be deleted soon
 // Instantiate API Pollers (if not in test mode)
 // if (PRODUCTION_MODE) {
 //   initReservoirBots()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opensea/stream-js@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@opensea/stream-js@npm:0.2.1"
+  dependencies:
+    phoenix: "npm:^1.6.15"
+  checksum: 10c0/4b693d6d04c8c842f20b69dda64ae1078f3e538c207d37027a43e7ea03339c07a9f4a6e27d8baa31084d27ef327217e79ddd312d5ce8cbe22ecd68a1ec5bc9d3
+  languageName: node
+  linkType: hard
+
 "@peculiar/asn1-schema@npm:^2.1.6":
   version: 2.3.0
   resolution: "@peculiar/asn1-schema@npm:2.3.0"
@@ -2994,6 +3003,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-localstorage@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@types/node-localstorage@npm:1.3.3"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/a33f2fe7c95c67a91219a85ea342dc1f201e1be2aed0883be55da32051ea8c814f6aeb420819d0f6b495b5027c61587aba378c6ca8a6368e435af51530bec48b
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 18.11.7
   resolution: "@types/node@npm:18.11.7"
@@ -3051,6 +3069,13 @@ __metadata:
   version: 1.6.0
   resolution: "@types/phoenix@npm:1.6.0"
   checksum: 10c0/5c3caf2028423b584680bf839b2579c4369a3c1388d33dbf9a8354be8b74c6357cba045f9a1ea32f92d5a6f6c78375c3e275a1d363fbf289aef50a2eea0d8748
+  languageName: node
+  linkType: hard
+
+"@types/phoenix@npm:^1.6.6":
+  version: 1.6.6
+  resolution: "@types/phoenix@npm:1.6.6"
+  checksum: 10c0/4dfcb3fd36341ed5500de030291af14163c599857e00d2d4ff065d4c4600317d5d20aa170913fb9609747a09436e3add44db7d0c709bdf80f36cddcc67a42021
   languageName: node
   linkType: hard
 
@@ -3630,10 +3655,13 @@ __metadata:
     "@graphql-codegen/typescript-urql": "npm:^3.7.3"
     "@graphql-codegen/urql-introspection": "npm:^2.2.1"
     "@graphql-tools/utils": "npm:^8.3.0"
+    "@opensea/stream-js": "npm:^0.2.1"
     "@reservoir0x/reservoir-sdk": "npm:^2.4.32"
     "@supabase/supabase-js": "npm:^2.29.0"
     "@types/node": "npm:20.1.2"
     "@types/node-cron": "npm:^3.0.8"
+    "@types/node-localstorage": "npm:^1.3.3"
+    "@types/phoenix": "npm:^1.6.6"
     "@typescript-eslint/eslint-plugin": "npm:^5.41.0"
     "@typescript-eslint/parser": "npm:^5.41.0"
     "@urql/exchange-retry": "npm:^1.0.0"
@@ -3658,6 +3686,7 @@ __metadata:
     ms: "npm:^2.0.0"
     node-fetch: "npm:^2.6.1"
     node-html-parser: "npm:^3.2.0"
+    node-localstorage: "npm:^3.0.5"
     openai: "npm:^4.73.0"
     prettier: "npm:^2.6.2"
     react: "npm:18.2.0"
@@ -3670,7 +3699,7 @@ __metadata:
     urql: "npm:^3.0.3"
     viem: "npm:2.17.4"
     web3: "npm:^1.7.0"
-    ws: "npm:^8.17.1"
+    ws: "npm:^8.18.3"
   languageName: unknown
   linkType: soft
 
@@ -9498,6 +9527,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-localstorage@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "node-localstorage@npm:3.0.5"
+  dependencies:
+    write-file-atomic: "npm:^5.0.1"
+  checksum: 10c0/ab042511e44bbeb0c18df4418bd0ec65fe574fa4bf492d8b7f2d96a0eccad722f9a26147cdf5c42c1c9d64da7b64b343f39a2d9862b7d7f4543fcb4ebec6f7da
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.6":
   version: 2.0.6
   resolution: "node-releases@npm:2.0.6"
@@ -10023,6 +10061,13 @@ __metadata:
   version: 2.1.0
   resolution: "performance-now@npm:2.1.0"
   checksum: 10c0/22c54de06f269e29f640e0e075207af57de5052a3d15e360c09b9a8663f393f6f45902006c1e71aa8a5a1cdfb1a47fe268826f8496d6425c362f00f5bc3e85d9
+  languageName: node
+  linkType: hard
+
+"phoenix@npm:^1.6.15":
+  version: 1.8.0
+  resolution: "phoenix@npm:1.8.0"
+  checksum: 10c0/12327c0af35fdb4eec433333e5b6581bd553cea5034a699fd5cfdd9e814ffd075d14593bbab1303ff5de607e9f5a1eaaa2bcb0c68a51a6a8011a968c71ccdeb7
   languageName: node
   linkType: hard
 
@@ -12673,6 +12718,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"write-file-atomic@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "write-file-atomic@npm:5.0.1"
+  dependencies:
+    imurmurhash: "npm:^0.1.4"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10c0/e8c850a8e3e74eeadadb8ad23c9d9d63e4e792bd10f4836ed74189ef6e996763959f1249c5650e232f3c77c11169d239cbfc8342fc70f3fe401407d23810505d
+  languageName: node
+  linkType: hard
+
 "ws@npm:7.4.6":
   version: 7.4.6
   resolution: "ws@npm:7.4.6"
@@ -12688,7 +12743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.17.1, ws@npm:^8.17.1, ws@npm:^8.3.0":
+"ws@npm:8.17.1, ws@npm:^8.3.0":
   version: 8.17.1
   resolution: "ws@npm:8.17.1"
   peerDependencies:
@@ -12726,6 +12781,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Switching to the [OpenSea Stream API](https://github.com/ProjectOpenSea/stream-js) for sale/list events! 

There is no contract level filtering on OS end, so it seems the only way is just to receive all sale/list events and manually filter by contract on our side

Sale bot is hooked up to Twitter so it all should work in theory!

Keeping the Reservoir code around in case we need to revert this, but i will open a ticket to remove it all once it is proven stable