### PR TITLE
hybrid opensea polling approach

### DIFF
--- a/src/Classes/APIBots/OpenSeaEventsPollBot.ts
+++ b/src/Classes/APIBots/OpenSeaEventsPollBot.ts
@@ -14,17 +14,17 @@ export interface OpenSeaEvent {
     timestamp: string
   }
   nft?: {
-    identifier: string
-    collection: string
+    identifier: string // token id within contract
+    collection?: string
     contract: string
-    token_standard: string
+    token_standard?: string
     name?: string
     description?: string
     image_url?: string
     metadata_url?: string
     opensea_url?: string
   }
-  quantity: number
+  quantity?: string | number // listing quantity; API uses strings for big ints
   seller?: {
     address: string
   }
@@ -32,7 +32,7 @@ export interface OpenSeaEvent {
     address: string
   }
   payment?: {
-    quantity: string
+    quantity: string // big integer string (wei-like)
     token_address?: string
     decimals?: number
     symbol?: string

--- a/src/Classes/APIBots/OpenSeaEventsPollBot.ts
+++ b/src/Classes/APIBots/OpenSeaEventsPollBot.ts
@@ -1,0 +1,294 @@
+import { Client } from 'discord.js'
+import axios from 'axios'
+
+const POLL_INTERVAL_MS = 15 * 1000 // 15 seconds
+const MAX_PAGES_PER_POLL = 3 // Limit pages to prevent runaway API calls
+const EVENTS_PER_PAGE = 50 // Typical OpenSea page size
+
+export interface OpenSeaEvent {
+  event_type: 'sale' | 'listing' | 'offer' | 'transfer' | 'cancel_listing'
+  chain: 'ethereum' | 'polygon' | 'arbitrum'
+  order_hash?: string
+  transaction?: {
+    hash: string
+    timestamp: string
+  }
+  nft?: {
+    identifier: string
+    collection: string
+    contract: string
+    token_standard: string
+    name?: string
+    description?: string
+    image_url?: string
+    metadata_url?: string
+    opensea_url?: string
+  }
+  quantity: number
+  seller?: {
+    address: string
+  }
+  buyer?: {
+    address: string
+  }
+  payment?: {
+    quantity: string
+    token_address?: string
+    decimals?: number
+    symbol?: string
+  }
+  closing_date?: string
+  listing_date?: string
+  expiration_date?: string
+  event_timestamp: string
+}
+
+export interface OpenSeaEventsResponse {
+  asset_events: OpenSeaEvent[]
+  next?: string
+}
+
+/**
+ * Base class for OpenSea Events API polling bots
+ * Handles pagination and filtering for high-volume event streams
+ */
+export abstract class OpenSeaEventsPollBot {
+  protected bot: Client
+  protected headers: { [key: string]: string }
+  protected lastUpdatedTime: number
+  protected intervalId?: NodeJS.Timeout
+  protected statsIntervalId?: NodeJS.Timeout
+  protected trackedContracts: string[]
+  protected eventType: 'sale' | 'listing'
+  protected missedEventCount = 0
+  protected totalPollCount = 0
+
+  constructor(
+    bot: Client,
+    eventType: 'sale' | 'listing',
+    trackedContracts: string[]
+  ) {
+    this.bot = bot
+    this.eventType = eventType
+    this.trackedContracts = trackedContracts.map((addr) => addr.toLowerCase())
+    this.headers = {
+      Accept: 'application/json',
+      'x-api-key': process.env.OPENSEA_API_KEY ?? '',
+    }
+
+    // Start polling from current time to avoid processing old events
+    this.lastUpdatedTime = Date.now()
+
+    // Start polling
+    this.startPolling()
+
+    // Start periodic statistics logging
+    this.startStatsLogging()
+  }
+
+  /**
+   * Start polling the OpenSea Events API
+   */
+  protected startPolling() {
+    this.intervalId = setInterval(() => {
+      this.pollEvents().catch((err) => {
+        console.error(`Error polling OpenSea ${this.eventType} events:`, err)
+      })
+    }, POLL_INTERVAL_MS)
+
+    console.log(
+      `Started OpenSea ${this.eventType} events polling (${POLL_INTERVAL_MS}ms interval)`
+    )
+  }
+
+  /**
+   * Start periodic statistics logging
+   */
+  protected startStatsLogging() {
+    // Log stats every 10 minutes
+    this.statsIntervalId = setInterval(() => {
+      const missedRate =
+        this.totalPollCount > 0
+          ? ((this.missedEventCount / this.totalPollCount) * 100).toFixed(2)
+          : '0.00'
+      console.log(
+        `📊 OpenSea ${this.eventType} polling stats: ${this.missedEventCount} missed events caught in ${this.totalPollCount} polls (${missedRate}% miss rate)`
+      )
+    }, 10 * 60 * 1000) // 10 minutes
+  }
+
+  /**
+   * Stop polling
+   */
+  protected stopPolling() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = undefined
+    }
+    if (this.statsIntervalId) {
+      clearInterval(this.statsIntervalId)
+      this.statsIntervalId = undefined
+    }
+  }
+
+  /**
+   * Cleanup method
+   */
+  cleanup() {
+    this.stopPolling()
+  }
+
+  /**
+   * Poll events with smart pagination
+   */
+  protected async pollEvents() {
+    try {
+      this.totalPollCount++
+      let cursor: string | undefined
+      let foundRelevantEvents = 0
+      let missedEventsThisPoll = 0
+      let processedEvents = 0
+      const startTime = Date.now()
+
+      // Convert lastUpdatedTime to ISO string for API
+      const occurredAfter = new Date(this.lastUpdatedTime).toISOString()
+
+      for (let page = 0; page < MAX_PAGES_PER_POLL; page++) {
+        const response = await this.fetchEventsPage(occurredAfter, cursor)
+
+        if (!response.asset_events || response.asset_events.length === 0) {
+          break
+        }
+
+        // Filter to relevant events immediately
+        const relevantEvents = response.asset_events.filter((event) =>
+          this.isRelevantEvent(event)
+        )
+
+        // Process relevant events and track missed ones
+        for (const event of relevantEvents) {
+          try {
+            const wasNewEvent = await this.processEvent(event)
+            foundRelevantEvents++
+            if (wasNewEvent) {
+              missedEventsThisPoll++
+            }
+          } catch (err) {
+            console.error(`Error processing ${this.eventType} event:`, err)
+          }
+        }
+
+        processedEvents += response.asset_events.length
+
+        // Update cursor for next page
+        cursor = response.next
+
+        // Break early if:
+        // 1. No more pages
+        // 2. Page wasn't full (likely caught up)
+        // 3. No relevant events found in this page (likely past our contracts)
+        if (
+          !cursor ||
+          response.asset_events.length < EVENTS_PER_PAGE ||
+          relevantEvents.length === 0
+        ) {
+          break
+        }
+      }
+
+      // Update missed event count
+      this.missedEventCount += missedEventsThisPoll
+
+      // Update timestamp to latest event time + 1ms to avoid duplicates
+      if (processedEvents > 0) {
+        this.lastUpdatedTime = Date.now()
+      }
+
+      if (foundRelevantEvents > 0) {
+        const missedText =
+          missedEventsThisPoll > 0
+            ? ` (${missedEventsThisPoll} missed by stream)`
+            : ''
+        console.log(
+          `OpenSea ${
+            this.eventType
+          } poll: found ${foundRelevantEvents} relevant events in ${processedEvents} total events${missedText} (${
+            Date.now() - startTime
+          }ms)`
+        )
+      }
+    } catch (err) {
+      console.error(`Error in OpenSea ${this.eventType} polling:`, err)
+    }
+  }
+
+  /**
+   * Fetch a single page of events from OpenSea API
+   */
+  protected async fetchEventsPage(
+    occurredAfter: string,
+    cursor?: string
+  ): Promise<OpenSeaEventsResponse> {
+    const params = new URLSearchParams({
+      event_type: this.eventType,
+      chain: 'ethereum',
+      occurred_after: occurredAfter,
+      limit: EVENTS_PER_PAGE.toString(),
+    })
+
+    if (cursor) {
+      params.append('next', cursor)
+    }
+
+    const url = `https://api.opensea.io/api/v2/events?${params.toString()}`
+
+    const response = await axios.get(url, {
+      headers: this.headers,
+      timeout: 30000, // 30 second timeout
+    })
+
+    return response.data
+  }
+
+  /**
+   * Check if an event is relevant to our tracked contracts
+   */
+  protected isRelevantEvent(event: OpenSeaEvent): boolean {
+    // Must be ethereum chain
+    if (event.chain !== 'ethereum') {
+      return false
+    }
+
+    // Must have NFT info
+    if (!event.nft?.contract) {
+      return false
+    }
+
+    // Must be one of our tracked contracts
+    const contractAddress = event.nft.contract.toLowerCase()
+    return this.trackedContracts.includes(contractAddress)
+  }
+
+  /**
+   * Process a single relevant event (to be implemented by subclasses)
+   * @returns true if this was a new event missed by stream, false if already processed
+   */
+  protected abstract processEvent(event: OpenSeaEvent): Promise<boolean>
+
+  /**
+   * Parse NFT identifier into contract and token ID
+   */
+  protected parseNftIdentifier(
+    identifier: string
+  ): { contractAddress: string; tokenId: string } | null {
+    const parts = identifier.split('/')
+    if (parts.length !== 3 || parts[0] !== 'ethereum') {
+      return null
+    }
+
+    return {
+      contractAddress: parts[1],
+      tokenId: parts[2],
+    }
+  }
+}

--- a/src/Classes/APIBots/OpenSeaListBot.ts
+++ b/src/Classes/APIBots/OpenSeaListBot.ts
@@ -30,6 +30,10 @@ export class OpenSeaListBot {
   } = {}
   private listColor = '#407FDB'
 
+  // Track processed events for missed event detection
+  private static processedEvents: Set<string> = new Set()
+  private static readonly MAX_PROCESSED_EVENTS = 10000 // Prevent memory leaks
+
   constructor(bot: Client) {
     this.bot = bot
 
@@ -54,12 +58,39 @@ export class OpenSeaListBot {
   /**
    * Main handler for OpenSea listing events
    * @param event - OpenSea stream event data
+   * @param source - Source of the event ('stream' or 'poll')
+   * @returns true if this was a missed event recovered by polling
    */
-  async handleListingEvent(event: ItemListedEvent) {
+  async handleListingEvent(
+    event: ItemListedEvent,
+    source: 'stream' | 'poll' = 'stream'
+  ): Promise<boolean> {
+    let missedByStream = false
     try {
+      // Generate unique event ID for tracking
+      const eventId = this.generateEventId(event.payload)
+
+      if (source === 'stream') {
+        // Track stream events
+        this.trackProcessedEvent(eventId)
+      } else if (source === 'poll') {
+        // Check if this was already processed by stream
+        if (OpenSeaListBot.processedEvents.has(eventId)) {
+          // Event was already processed by stream, skip sending and not missed
+          return false
+        } else {
+          // This is a missed event caught by polling!
+          missedByStream = true
+          console.log(`🔍 OpenSea LISTING poll caught missed event: ${eventId}`)
+          this.trackProcessedEvent(eventId)
+        }
+      }
+
       await this.buildDiscordMessage(event.payload)
+      return missedByStream
     } catch (err) {
       console.error('Error processing OpenSea listing event:', err)
+      return false
     }
   }
 
@@ -221,6 +252,43 @@ export class OpenSeaListBot {
     } catch (error) {
       console.error('Error building OpenSea listing message:', error)
     }
+  }
+
+  /**
+   * Generate unique event ID for tracking duplicates
+   */
+  private generateEventId(payload: ItemListedEvent['payload']): string {
+    // Use contract, token, price, and maker as unique identifier
+    const contract = payload.item.nft_id.split('/')[1] || ''
+    const tokenId = payload.item.nft_id.split('/')[2] || ''
+    const price = payload.payment_token.eth_price
+    const maker = payload.maker.address
+    return `listing:${contract}:${tokenId}:${price}:${maker}`
+  }
+
+  /**
+   * Track processed event and manage memory
+   */
+  private trackProcessedEvent(eventId: string) {
+    OpenSeaListBot.processedEvents.add(eventId)
+
+    // Prevent memory leaks by trimming old events
+    if (
+      OpenSeaListBot.processedEvents.size > OpenSeaListBot.MAX_PROCESSED_EVENTS
+    ) {
+      const eventsArray = Array.from(OpenSeaListBot.processedEvents)
+      const toKeep = eventsArray.slice(
+        -Math.floor(OpenSeaListBot.MAX_PROCESSED_EVENTS * 0.8)
+      )
+      OpenSeaListBot.processedEvents = new Set(toKeep)
+    }
+  }
+
+  /**
+   * Get count of tracked events (for monitoring)
+   */
+  static getTrackedEventCount(): number {
+    return OpenSeaListBot.processedEvents.size
   }
 
   /**

--- a/src/Classes/APIBots/OpenSeaListPollBot.ts
+++ b/src/Classes/APIBots/OpenSeaListPollBot.ts
@@ -42,14 +42,12 @@ export class OpenSeaListPollBot extends OpenSeaEventsPollBot {
    * Convert Events API event to Stream API format
    */
   private convertToStreamFormat(event: OpenSeaEvent): any | null {
-    if (!event.nft?.identifier || !event.payment) {
+    if (!event.nft?.identifier || !event.nft.contract || !event.payment) {
       return null
     }
 
-    const nftInfo = this.parseNftIdentifier(event.nft.identifier)
-    if (!nftInfo) {
-      return null
-    }
+    // Build stream nft_id from Events API fields: "chain/contract/tokenId"
+    const nftId = `${event.chain}/${event.nft.contract}/${event.nft.identifier}`
 
     // For listings, we need to estimate ETH price from payment quantity
     // The Events API provides the raw payment amount
@@ -62,7 +60,7 @@ export class OpenSeaListPollBot extends OpenSeaEventsPollBot {
     return {
       payload: {
         item: {
-          nft_id: event.nft.identifier,
+          nft_id: nftId,
         },
         payment_token: {
           symbol: event.payment.symbol || 'ETH',

--- a/src/Classes/APIBots/OpenSeaListPollBot.ts
+++ b/src/Classes/APIBots/OpenSeaListPollBot.ts
@@ -1,0 +1,101 @@
+import { Client } from 'discord.js'
+import { OpenSeaEventsPollBot, OpenSeaEvent } from './OpenSeaEventsPollBot'
+import { OpenSeaListBot } from './OpenSeaListBot'
+
+/**
+ * Polling bot for OpenSea listing events
+ * Works alongside the stream to catch missed events
+ */
+export class OpenSeaListPollBot extends OpenSeaEventsPollBot {
+  private listBot: OpenSeaListBot
+
+  constructor(bot: Client, trackedContracts: string[]) {
+    super(bot, 'listing', trackedContracts)
+
+    // Create a list bot instance to reuse existing message building logic
+    this.listBot = new OpenSeaListBot(bot)
+  }
+
+  /**
+   * Process a listing event by converting it to stream format and delegating
+   * @returns true if this was a new event missed by stream, false if already processed
+   */
+  protected async processEvent(event: OpenSeaEvent): Promise<boolean> {
+    // Convert OpenSea Events API format to Stream API format
+    const streamEvent = this.convertToStreamFormat(event)
+
+    if (streamEvent) {
+      // Delegate to existing OpenSeaListBot logic with 'poll' source and use return value
+      const missedByStream = await this.listBot.handleListingEvent(
+        streamEvent,
+        'poll'
+      )
+      return missedByStream
+    }
+
+    return false
+  }
+
+  // No separate event ID or processed checks needed; handled inside list bot
+
+  /**
+   * Convert Events API event to Stream API format
+   */
+  private convertToStreamFormat(event: OpenSeaEvent): any | null {
+    if (!event.nft?.identifier || !event.payment) {
+      return null
+    }
+
+    const nftInfo = this.parseNftIdentifier(event.nft.identifier)
+    if (!nftInfo) {
+      return null
+    }
+
+    // For listings, we need to estimate ETH price from payment quantity
+    // The Events API provides the raw payment amount
+    const ethPrice = this.estimateEthPrice(
+      event.payment.quantity,
+      event.payment.decimals || 18
+    )
+
+    // Convert to stream event format that OpenSeaListBot expects
+    return {
+      payload: {
+        item: {
+          nft_id: event.nft.identifier,
+        },
+        payment_token: {
+          symbol: event.payment.symbol || 'ETH',
+          decimals: event.payment.decimals || 18,
+          eth_price: ethPrice.toString(),
+        },
+        maker: {
+          address: event.seller?.address || '',
+        },
+        listing_date: event.event_timestamp,
+      },
+    }
+  }
+
+  /**
+   * Estimate ETH price from payment quantity and decimals
+   */
+  private estimateEthPrice(quantity: string, decimals: number): number {
+    try {
+      // Convert from wei-like units to ETH-like units
+      const price = parseInt(quantity) / Math.pow(10, decimals)
+      return price
+    } catch (err) {
+      console.warn('Failed to parse payment quantity:', quantity)
+      return 0
+    }
+  }
+
+  /**
+   * Override cleanup to also cleanup the list bot
+   */
+  cleanup() {
+    super.cleanup()
+    this.listBot.cleanup()
+  }
+}

--- a/src/Classes/APIBots/OpenSeaSalePollBot.ts
+++ b/src/Classes/APIBots/OpenSeaSalePollBot.ts
@@ -47,20 +47,18 @@ export class OpenSeaSalePollBot extends OpenSeaEventsPollBot {
    * Convert Events API event to Stream API format
    */
   private convertToStreamFormat(event: OpenSeaEvent): any | null {
-    if (!event.nft?.identifier || !event.payment) {
+    if (!event.nft?.identifier || !event.nft.contract || !event.payment) {
       return null
     }
 
-    const nftInfo = this.parseNftIdentifier(event.nft.identifier)
-    if (!nftInfo) {
-      return null
-    }
+    // Build stream nft_id from Events API fields: "chain/contract/tokenId"
+    const nftId = `${event.chain}/${event.nft.contract}/${event.nft.identifier}`
 
     // Convert to stream event format that OpenSeaSaleBot expects
     return {
       payload: {
         item: {
-          nft_id: event.nft.identifier,
+          nft_id: nftId,
         },
         sale_price: event.payment.quantity, // Already in wei from Events API
         payment_token: {

--- a/src/Classes/APIBots/OpenSeaSalePollBot.ts
+++ b/src/Classes/APIBots/OpenSeaSalePollBot.ts
@@ -1,0 +1,89 @@
+import { Client } from 'discord.js'
+import { OpenSeaEventsPollBot, OpenSeaEvent } from './OpenSeaEventsPollBot'
+import { OpenSeaSaleBot } from './OpenSeaSaleBot'
+import { TwitterBot } from '../TwitterBot'
+
+/**
+ * Polling bot for OpenSea sale events
+ * Works alongside the stream to catch missed events
+ */
+export class OpenSeaSalePollBot extends OpenSeaEventsPollBot {
+  private saleBot: OpenSeaSaleBot
+
+  constructor(
+    bot: Client,
+    trackedContracts: string[],
+    twitterBot?: TwitterBot
+  ) {
+    super(bot, 'sale', trackedContracts)
+
+    // Create a sale bot instance to reuse existing message building logic
+    this.saleBot = new OpenSeaSaleBot(bot, twitterBot)
+  }
+
+  /**
+   * Process a sale event by converting it to stream format and delegating
+   * @returns true if this was a new event missed by stream, false if already processed
+   */
+  protected async processEvent(event: OpenSeaEvent): Promise<boolean> {
+    // Convert OpenSea Events API format to Stream API format
+    const streamEvent = this.convertToStreamFormat(event)
+
+    if (streamEvent) {
+      // Delegate to existing OpenSeaSaleBot logic with 'poll' source and use return value
+      const missedByStream = await this.saleBot.handleSaleEvent(
+        streamEvent,
+        'poll'
+      )
+      return missedByStream
+    }
+
+    return false
+  }
+
+  // No separate event ID or processed checks needed; handled inside sale bot
+
+  /**
+   * Convert Events API event to Stream API format
+   */
+  private convertToStreamFormat(event: OpenSeaEvent): any | null {
+    if (!event.nft?.identifier || !event.payment) {
+      return null
+    }
+
+    const nftInfo = this.parseNftIdentifier(event.nft.identifier)
+    if (!nftInfo) {
+      return null
+    }
+
+    // Convert to stream event format that OpenSeaSaleBot expects
+    return {
+      payload: {
+        item: {
+          nft_id: event.nft.identifier,
+        },
+        sale_price: event.payment.quantity, // Already in wei from Events API
+        payment_token: {
+          symbol: event.payment.symbol || 'ETH',
+          decimals: event.payment.decimals || 18,
+          usd_price: '0', // Events API doesn't provide USD price directly
+        },
+        maker: {
+          address: event.seller?.address || '',
+        },
+        taker: {
+          address: event.buyer?.address || '',
+        },
+        closing_date: event.event_timestamp,
+      },
+    }
+  }
+
+  /**
+   * Override cleanup to also cleanup the sale bot
+   */
+  cleanup() {
+    super.cleanup()
+    this.saleBot.cleanup()
+  }
+}

--- a/src/Utils/activityTriager.ts
+++ b/src/Utils/activityTriager.ts
@@ -33,7 +33,6 @@ const FLUTTER_SALES = projectConfig.chIdByName['flutter-sales']
 const TENDER_SALES = projectConfig.chIdByName['tender-sales']
 const HODLERS_SALES = projectConfig.chIdByName['hodlers-sales']
 const HODLERS_LISTINGS = projectConfig.chIdByName['hodlers-listings']
-const PROOF = projectConfig.chIdByName['proof-all']
 
 // Addresses which should be omitted entirely from event feeds.
 export const BAN_ADDRESSES = new Set([
@@ -215,12 +214,6 @@ export function sendEmbedToSaleChannels(
       artBlocksData.platform.includes('Sotheby')
     ) {
       sendEmbedToChannel(bot, embed, TENDER_SALES)
-    }
-    if (
-      artBlocksData.platform.toLowerCase().includes('proof') ||
-      artBlocksData.platform.includes('Art Blocks')
-    ) {
-      sendEmbedToChannel(bot, embed, PROOF)
     }
   } catch (e) {
     console.warn(e)


### PR DESCRIPTION
Adding a hybrid websocket / polling approach to the opensea API. We ran into an issue where somehow messages are being dropped / stream api isn't delivering certain events. Their API endpoint should return all events. 

Probably should/will switch to a full poller in the future, but for now just adding the poller as a quick catch all for the events that slip through the cracks, plus adding statistics logging so we can see how often events are missed - this will be valuable info for other reservoir replacement work down the line! If events are only missed rarely then we can probably keep this in place to limit the amount of spam polling

